### PR TITLE
Moved static outside of function

### DIFF
--- a/src/net/class_ip6.cpp
+++ b/src/net/class_ip6.cpp
@@ -91,9 +91,10 @@ namespace net
     return 0;
 	};
   
+  static const std::string lut = "0123456789abcdef";
+  
   std::string IP6::addr::to_string() const
   {
-    static const std::string lut = "0123456789abcdef";
     std::string ret(40, 0);
     int counter = 0;
     


### PR DESCRIPTION
Fixes __cxa_guard_\* needed to protect static data inside of reentrant function
... even though there is no reentrancy
