### PR TITLE
Adding a script to prepend a license header to source files

### DIFF
--- a/etc/apply_license.sh
+++ b/etc/apply_license.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+licenselen=$(wc -l < license.txt)
+extensions="hpp cpp h c"
+donotcheck="./api/SQLite ./src/crt/cxxabi ./src/include/cxxabi.h ./src/include/__cxxabi_config.h *sanos* ./doc"
+for extension in $extensions ; do
+	for line in $(find .. -iname "*.$extension"); do 
+	     echo "Now processing file: $line"
+	     for item in $donotcheck; do
+		if [[ $(echo $line | grep $item) ]] ; then
+			echo "Bypassing file"; 
+			break;
+		fi
+		head -n $licenselen $line > ./tmpfile
+		if [[ $(diff license.txt ./tmpfile) ]]; then	
+	    		 head -n 10 $line; 
+			 PS3='What would you like to do? (1-2)? '; 
+			 select answer in "Add license text from license.txt" "Do nothing and proceed to next file"; do
+			 if [[ $answer = "Add license text from license.txt" ]]; then
+				{ echo Adding license;
+				( cat license.txt; echo; cat $line ) > /tmp/file; 
+				mv /tmp/file $line 
+				break; }
+			elif [[ $answer = "Do nothing and proceed to next file" ]]; then {
+				echo Okay, doing nothing; 
+				break; }
+			else {
+				echo Please select one of the alternatives.
+			} fi
+	     	done
+	
+		else	
+			echo "License OK";
+			break;
+		fi
+
+	done
+done
+done

--- a/etc/license.txt
+++ b/etc/license.txt
@@ -1,0 +1,16 @@
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and  Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//


### PR DESCRIPTION
Script will iterate through all .hpp, .cpp, .h and .c files, except those in the exclude-list, and check if the license text is already there. If it is not, the user is asked if you want to add the text or not. Does not take any parameters, but relies on license.txt being in the same directory. Extensions and excluded directories are at the top of the script.
