### PR TITLE
Conan: Updated chainloader to use major_mode + new python_requires git

### DIFF
--- a/src/chainload/conanfile.py
+++ b/src/chainload/conanfile.py
@@ -1,28 +1,10 @@
-from conans import ConanFile,tools,CMake
+from conans import ConanFile, python_requires, CMake
 
-def get_version():
-    git = tools.Git()
-    try:
-        prev_tag = git.run("describe --tags --abbrev=0")
-        commits_behind = int(git.run("rev-list --count %s..HEAD" % (prev_tag)))
-        # Commented out checksum due to a potential bug when downloading from bintray
-        #checksum = git.run("rev-parse --short HEAD")
-        if prev_tag.startswith("v"):
-            prev_tag = prev_tag[1:]
-        if commits_behind > 0:
-            prev_tag_split = prev_tag.split(".")
-            prev_tag_split[-1] = str(int(prev_tag_split[-1]) + 1)
-            output = "%s-%d" % (".".join(prev_tag_split), commits_behind)
-        else:
-            output = "%s" % (prev_tag)
-        return output
-    except:
-        return '0.0.0'
-
+conan_tools = python_requires("conan-tools/[>=1.0.0]@includeos/stable")
 
 class ChainloaderConan(ConanFile):
     name = "chainloader"
-    version=get_version()
+    version = conan_tools.git_get_semver()
     license = 'Apache-2.0'
     description = 'IncludeOS 32->64 bit chainloader for x86'
     generators = ['cmake','virtualenv']
@@ -44,12 +26,12 @@ class ChainloaderConan(ConanFile):
     default_user="includeos"
     default_channel="test"
 
-    #def requirements(self):
-    #    self.requires("includeos/[>=0.14.0,include_prerelease=True]@{}/{}".format(self.user,self.channel),private=True)
+    def package_id(self):
+        self.info.requires.major_mode()
 
     def build_requirements(self):
-        self.build_requires("vmbuild/[>=0.14.0,include_prerelease=True]@{}/{}".format(self.user,self.channel))
         self.build_requires("includeos/[>=0.14.0,include_prerelease=True]@{}/{}".format(self.user,self.channel))
+        self.build_requires("vmbuild/[>=0.14.0,include_prerelease=True]@includeos/latest")
 
     def _configure_cmake(self):
         cmake = CMake(self)


### PR DESCRIPTION
I think it makes sense to use `major_mode` for this package as well.

I had to change the dependency on `vmbuild` to a hard-coded channel. It does not make sense to have transitive dependencies for that one. 