### PR TITLE
fix CMake out of source build failing due to incbin instruction

### DIFF
--- a/lib/LiveUpdate/CMakeLists.txt
+++ b/lib/LiveUpdate/CMakeLists.txt
@@ -30,6 +30,10 @@ add_library(liveupdate STATIC
     os.cpp serialize_tcp.cpp hotswap.cpp hotswap64_blob.asm
     ${LIU_OPENSSL_FILES}
   )
+
+# to allow out of source build, even if hotswap64_blob.asm contains incbin "hotswap64.bin"
+set_source_files_properties(hotswap64_blob.asm PROPERTIES COMPILE_FLAGS "-I ${CMAKE_CURRENT_BINARY_DIR}/")
+
 add_dependencies(liveupdate hotswap64)
 add_dependencies(liveupdate PrecompiledLibraries)
 


### PR DESCRIPTION
To fix this error I got when building out of source (Fedora 29,  Qt Creator 4.7.2):

/home/ilelann/src/IncludeOS/lib/LiveUpdate/hotswap64_blob.asm:21: error: `incbin': unable to get length of file `hotswap64.bin'

With this patch, you can just open CMakeLists.txt in Qt Creator and things seem to build fine.
Only assuming an override of CMAKE_INSTALL_PREFIX in CMake Configuration of used Qt Creator kit to work around the IDE trying to write to /usr/local .

Disclaimer:
I am totally new to IncludeOS. Currently playing with it. 
So this is not tested and I have no idea if this breaks the whole universe. :)