### PR TITLE
upgrading subprocess calls to python3

### DIFF
--- a/test/fs/integration/fat32/test.py
+++ b/test/fs/integration/fat32/test.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import sys
 import os
 import subprocess
-import subprocess32
 
 thread_timeout = 30
 from vmrunner import vmrunner
@@ -17,7 +16,7 @@ def cleanup():
 
 cleanup()
 # Setup disk
-subprocess32.call(["./fat32_disk.sh"], shell=True, timeout=thread_timeout)
+subprocess.call(["./fat32_disk.sh"], shell=True, timeout=thread_timeout)
 
 # Clean up on exit
 vm.on_exit(cleanup)

--- a/test/fs/integration/ide/test.py
+++ b/test/fs/integration/ide/test.py
@@ -4,7 +4,6 @@ from builtins import str
 import sys
 import os
 import subprocess
-import subprocess32
 
 thread_timeout = 30
 
@@ -22,7 +21,7 @@ def cleanup():
     print(subprocess.check_output(["./fat32_disk.sh", "clean"]))
 
 # Setup disk
-subprocess32.call(["./fat32_disk.sh"], shell=True, timeout=thread_timeout)
+subprocess.call(["./fat32_disk.sh"], shell=True, timeout=thread_timeout)
 
 # Clean up on exit
 vm.on_exit(cleanup)

--- a/test/fs/integration/ide_write/test.py
+++ b/test/fs/integration/ide_write/test.py
@@ -4,7 +4,6 @@ from builtins import str
 import sys
 import os
 import subprocess
-import subprocess32
 
 thread_timeout = 30
 
@@ -22,7 +21,7 @@ def cleanup():
     print(subprocess.check_output(["./fat32_disk.sh", "clean"]))
 
 # Setup disk
-subprocess32.call(["./fat32_disk.sh"], shell=True, timeout = thread_timeout)
+subprocess.call(["./fat32_disk.sh"], shell=True, timeout = thread_timeout)
 
 # Clean up on exit
 vm.on_exit(cleanup)

--- a/test/fs/integration/vfs/test.py
+++ b/test/fs/integration/vfs/test.py
@@ -4,7 +4,6 @@ from builtins import str
 import sys
 import subprocess
 import os
-import subprocess32
 
 thread_timeout = 20
 
@@ -17,11 +16,11 @@ def cleanup():
     for disk in disks:
         diskname = disk + ".disk"
         print("Removing disk file ", diskname)
-        subprocess32.check_call(["rm", "-f", diskname], timeout=thread_timeout)
+        subprocess.check_call(["rm", "-f", diskname], timeout=thread_timeout)
 
 # Create all data disk images from folder names
 for disk in disks:
-  subprocess32.check_call(["./create_disk.sh", disk, disk])
+  subprocess.check_call(["./create_disk.sh", disk, disk])
 vm = vmrunner.vms[0]
 
 vm.on_exit_success(cleanup)

--- a/test/fs/integration/virtio_block/test.py
+++ b/test/fs/integration/virtio_block/test.py
@@ -2,12 +2,11 @@
 from builtins import str
 import sys
 import subprocess
-import subprocess32
 import os
 
 thread_timeout = 50
 
-subprocess32.call(['./image.sh'], timeout=thread_timeout)
+subprocess.call(['./image.sh'], timeout=thread_timeout)
 
 def cleanup():
   subprocess.call(['./cleanup.sh'])

--- a/test/net/integration/dhclient/test.py
+++ b/test/net/integration/dhclient/test.py
@@ -6,7 +6,6 @@ import sys
 import os
 import time
 import subprocess
-import subprocess32
 
 thread_timeout = 20
 
@@ -29,7 +28,7 @@ def DHCP_test(trigger_line):
   try:
     command = ["ping", ip_string.rstrip(), "-c", str(ping_count), "-i", "0.2"]
     print(color.DATA(" ".join(command)))
-    print(subprocess32.check_output(command, timeout=thread_timeout))
+    print(subprocess.check_output(command, timeout=thread_timeout))
     vm.exit(0,"<Test.py> Ping test passed. Process returned 0 exit status")
   except Exception as e:
     print(color.FAIL("<Test.py> Ping FAILED Process threw exception:"))

--- a/test/net/integration/dhcpd/test.py
+++ b/test/net/integration/dhcpd/test.py
@@ -6,7 +6,6 @@ import sys
 import os
 import time
 import subprocess
-import subprocess32
 
 thread_timeout = 20
 
@@ -30,7 +29,7 @@ def DHCP_test(trigger_line):
   try:
     command = ["ping", "-c", str(ping_count), "-i", "0.2", ip_string.rstrip()]
     print(color.DATA(" ".join(command)))
-    print(subprocess32.check_output(command, timeout=thread_timeout))
+    print(subprocess.check_output(command, timeout=thread_timeout))
     print(color.INFO("<Test.py>"), "Number of ping tests passed: ", str(num_assigned_clients))
     if num_assigned_clients == 3:
       vm.exit(0,"<Test.py> Ping test for all 3 clients passed. Process returned 0 exit status")

--- a/test/net/integration/dhcpd_dhclient_linux/test.py
+++ b/test/net/integration/dhcpd_dhclient_linux/test.py
@@ -6,7 +6,6 @@ import sys
 import os
 import time
 import subprocess
-import subprocess32
 
 thread_timeout = 20
 
@@ -74,7 +73,7 @@ def ping_test():
   try:
     command = ["ping", assigned_ip, "-c", str(ping_count), "-i", "0.2"]
     print(color.DATA(" ".join(command)))
-    print(subprocess32.check_output(command, timeout=thread_timeout))
+    print(subprocess.check_output(command, timeout=thread_timeout))
     ping_passed = True
   except Exception as e:
     print(color.FAIL("<Test.py> Ping FAILED Process threw exception:"))
@@ -88,17 +87,17 @@ def run_dhclient(trigger_line):
   route_output = subprocess.check_output(["route"])
 
   if "10.0.0.0" not in route_output:
-    subprocess32.call(["sudo", "ifconfig", "bridge43", "10.0.0.1", "netmask", "255.255.0.0", "up"], timeout=thread_timeout)
+    subprocess.call(["sudo", "ifconfig", "bridge43", "10.0.0.1", "netmask", "255.255.0.0", "up"], timeout=thread_timeout)
     time.sleep(1)
 
   if "10.200.0.0" not in route_output:
-    subprocess32.call(["sudo", "route", "add", "-net", "10.200.0.0", "netmask", "255.255.0.0", "dev", "bridge43"], timeout=thread_timeout)
+    subprocess.call(["sudo", "route", "add", "-net", "10.200.0.0", "netmask", "255.255.0.0", "dev", "bridge43"], timeout=thread_timeout)
     print(color.INFO("<Test.py>"), "Route added to bridge43, 10.200.0.0")
 
   print(color.INFO("<Test.py>"), "Running dhclient")
 
   try:
-    dhclient = subprocess32.check_output(
+    dhclient = subprocess.check_output(
         ["sudo", "dhclient", "bridge43", "-4", "-n", "-v"],
         stderr=subprocess.STDOUT,
         timeout=thread_timeout

--- a/test/net/integration/dns/test.py
+++ b/test/net/integration/dns/test.py
@@ -4,7 +4,6 @@ from builtins import str
 import sys
 import os
 import subprocess
-import subprocess32
 
 thread_timeout = 20
 

--- a/test/net/integration/icmp/test.py
+++ b/test/net/integration/icmp/test.py
@@ -6,7 +6,6 @@ from builtins import range
 import sys
 import os
 import subprocess
-import subprocess32
 
 thread_timeout = 50
 
@@ -68,7 +67,7 @@ def start_icmp_test(trigger_line):
   # 2 Port unreachable
   print(color.INFO("<Test.py>"), "Performing Destination Unreachable (port) test")
   # Sending 1 udp packet to 10.0.0.45 to port 8080
-  udp_port_output = subprocess32.check_output(["sudo", "hping3", "10.0.0.45", "--udp", "-p", "8080", "-c", "1"], timeout=thread_timeout).decode("utf-8")
+  udp_port_output = subprocess.check_output(["sudo", "hping3", "10.0.0.45", "--udp", "-p", "8080", "-c", "1"], timeout=thread_timeout).decode("utf-8")
   print(udp_port_output)
 
   # Validate content in udp_port_output:
@@ -81,7 +80,7 @@ def start_icmp_test(trigger_line):
   # 3 Protocol unreachable
   print(color.INFO("<Test.py>"), "Performing Destination Unreachable (protocol) test")
   # Sending 1 raw ip packet to 10.0.0.45 with protocol 16
-  rawip_protocol_output = subprocess32.check_output(["sudo", "hping3", "10.0.0.45", "-d", "20", "-0", "--ipproto", "16", "-c", "1"], timeout=thread_timeout).decode("utf-8")
+  rawip_protocol_output = subprocess.check_output(["sudo", "hping3", "10.0.0.45", "-d", "20", "-0", "--ipproto", "16", "-c", "1"], timeout=thread_timeout).decode("utf-8")
   print(rawip_protocol_output)
 
   # Validate content in rawip_protocol_output:

--- a/test/net/integration/router/test.py
+++ b/test/net/integration/router/test.py
@@ -7,7 +7,6 @@ from builtins import str
 import sys
 import os
 import subprocess
-import subprocess32
 import _thread
 import time
 
@@ -36,7 +35,7 @@ def iperf_server():
 
 def iperf_client(o):
     print("Starting iperf client. Iperf output: ")
-    print(subprocess32.check_output([iperf_cmd,"-c","10.42.42.2","-n", transmit_size], timeout=thread_timeout))
+    print(subprocess.check_output([iperf_cmd,"-c","10.42.42.2","-n", transmit_size], timeout=thread_timeout))
     vmrunner.vms[0].exit(0, "Test completed without errors")
     return True
 

--- a/test/stress/test.py
+++ b/test/stress/test.py
@@ -8,7 +8,6 @@ import sys
 import socket
 import time
 import subprocess
-import subprocess32
 import os
 
 from vmrunner import vmrunner
@@ -112,13 +111,13 @@ def UDP_burst(burst_size = BURST_SIZE, burst_interval = BURST_INTERVAL):
 # Fire a single burst of ICMP packets
 def ICMP_flood(burst_size = BURST_SIZE, burst_interval = BURST_INTERVAL):
   # Note: Ping-flooding requires sudo for optimal speed
-  res = subprocess32.check_call(["sudo","ping","-f", HOST, "-c", str(burst_size)], timeout=thread_timeout);
+  res = subprocess.check_call(["sudo","ping","-f", HOST, "-c", str(burst_size)], timeout=thread_timeout);
   time.sleep(burst_interval)
   return get_mem()
 
 # Fire a single burst of HTTP requests
 def httperf(burst_size = BURST_SIZE, burst_interval = BURST_INTERVAL):
-  res = subprocess32.check_call(["httperf","--hog", "--server", HOST, "--num-conn", str(burst_size)], timeout=thread_timeout);
+  res = subprocess.check_call(["httperf","--hog", "--server", HOST, "--num-conn", str(burst_size)], timeout=thread_timeout);
   time.sleep(burst_interval)
   return get_mem()
 
@@ -128,7 +127,7 @@ def ARP_burst(burst_size = BURST_SIZE, burst_interval = BURST_INTERVAL):
   command = ["sudo", "arping", "-q","-W", str(0.0001), "-I", "bridge43", "-c", str(burst_size * 10),  HOST]
   print(color.DATA(" ".join(command)))
   time.sleep(0.5)
-  res = subprocess32.check_call(command, timeout=thread_timeout);
+  res = subprocess.check_call(command, timeout=thread_timeout);
   time.sleep(burst_interval)
   return get_mem()
 


### PR DESCRIPTION
Tests updated:

**fs/integration/**
* fat32/test.py
* ide_write/test.py
* ide/test.py
* vfs/test.py
* virtio_block/test.py

**net/integration/**
* dhclient/test.py
* dhcpd_dhclient_linux/test.py
* dhcpd/test.py
* dns/test.py
* icmp/test.py
* router/test.py

**stress/**
* test.py

**What I did:**
- removed `import subprocess32` and ensure `import subprocess` is present
- replaced all `subprocess32` calls with `subprocess` calls and ensure the function calls exist/works.
   ref: https://docs.python.org/3/library/subprocess.html
- verified the syntax with `python -m compileall test`
PR to Upstream/dev will now run the network tests to ensure they work as intended.
