### PR TITLE
uplink: fixes to make remote drivers/plugins work

### DIFF
--- a/api/os.hpp
+++ b/api/os.hpp
@@ -47,7 +47,8 @@ namespace os {
   /** Enter the main event loop.  Trigger subscribed and triggerd events */
   void event_loop();
 
-
+  /** Have we booted up or are we resuming */
+  bool is_booted() noexcept;
   /**
    *  Halt until next event.
    *

--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -147,9 +147,16 @@ function(os_add_executable TARGET NAME)
 
   set_target_properties(${ELF_TARGET} PROPERTIES LINK_FLAGS ${LDFLAGS})
   conan_find_libraries_abs_path("${CONAN_LIBS}" "${CONAN_LIB_DIRS}" LIBRARIES)
-  target_link_libraries(${ELF_TARGET} ${LIBRARIES})
 
-
+  foreach(_LIB ${LIBRARIES})
+    get_filename_component(_PATH ${_LIB} DIRECTORY)
+    if (_PATH MATCHES ".*drivers" OR _PATH MATCHES ".*plugins" OR _PATH MATCHES ".*stdout")
+      message(STATUS "Whole Archive " ${_LIB})
+      os_link_libraries(${TARGET} --whole-archive ${_LIB} --no-whole-archive)
+    else()
+      target_link_libraries(${ELF_TARGET} ${_LIB})
+    endif()
+  endforeach()
 
   # TODO: if not debug strip
   if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/kernel/os.cpp
+++ b/src/kernel/os.cpp
@@ -17,6 +17,9 @@
 #include <os.hpp>
 #include <kernel.hpp>
 
+bool os::is_booted() noexcept {
+  return kernel::is_booted();
+}
 const char* os::arch() noexcept {
   return Arch::name;
 }


### PR DESCRIPTION
for external libraries and drivers to work --whole-archive was missing..
To get a hold of is_booted() the function was needed in os.hpp/os.cpp