### PR TITLE
Tests: Cleansing ifconfig from all tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
           sh script: "conan install $SRC/test -pr $PROFILE_x86_64", label: "Conan install"
           sh script: ". ./activate.sh; cmake $SRC/test -DCMAKE_BUILD_TYPE=Debug", label: "Cmake"
           sh script: "make -j $CPUS", label: "Make"
-          sh script: "ctest", label: "Ctest"
+          sh script: "ctest --schedule-random", label: "Ctest"
         }
       }
     }
@@ -61,7 +61,7 @@ pipeline {
           sh script: "conan install $SRC/test/integration -pr $PROFILE_x86_64", label: "Conan install"
           sh script: ". ./activate.sh; cmake $SRC/test/integration -DSTRESS=ON -DCMAKE_BUILD_TYPE=Debug", label: "Cmake"
           sh script: "make -j $CPUS", label: "Make"
-          sh script: "ctest -E stress --output-on-failure", label: "Tests"
+          sh script: "ctest -E stress --output-on-failure --schedule-random", label: "Tests"
           sh script: "ctest -R stress -E integration --output-on-failure", label: "Stress test"
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,15 +83,14 @@ pipeline {
       }
     }
     stage('Upload to bintray') {
+      when {
+        anyOf {
+          branch 'master'
+          branch 'dev'
+        }
+      }
       parallel {
         stage('Latest release') {
-          when {
-            anyOf {
-              branch 'master'
-              branch 'dev'
-              buildingTag()
-            }
-          }
           steps {
             upload_package("includeos", "$CHAN_LATEST")
             upload_package("liveupdate", "$CHAN_LATEST")

--- a/test/integration/run_test.sh
+++ b/test/integration/run_test.sh
@@ -7,4 +7,4 @@ arguments=$@
 source ${build_folder}/activate.sh
 #sudo prior to timeout. in case its needed inside
 sudo echo "sudo trigger"
-timeout -s 2 $timeout python3 -u test.py $arguments || echo "Test timed out"; sleep 1
+timeout -s 2 $timeout python3 -u test.py $arguments || echo "Test timed out in $timeout seconds"; sleep 1

--- a/test/net/integration/dhcpd_dhclient_linux/test.py
+++ b/test/net/integration/dhcpd_dhclient_linux/test.py
@@ -87,11 +87,11 @@ def run_dhclient(trigger_line):
   route_output = subprocess.check_output(["route"])
 
   if "10.0.0.0" not in route_output:
-    subprocess.call(["sudo", "ifconfig", "bridge43", "10.0.0.1", "netmask", "255.255.0.0", "up"], timeout=thread_timeout)
+    subprocess.call(["sudo", "ip", "link", "set", "dev", "bridge43", "up"], timeout=thread_timeout)
     time.sleep(1)
 
   if "10.200.0.0" not in route_output:
-    subprocess.call(["sudo", "route", "add", "-net", "10.200.0.0", "netmask", "255.255.0.0", "dev", "bridge43"], timeout=thread_timeout)
+    subprocess.call(["sudo", "ip", "route", "add", "10.200.0.0/16", "dev", "bridge43"], timeout=thread_timeout)
     print(color.INFO("<Test.py>"), "Route added to bridge43, 10.200.0.0")
 
   print(color.INFO("<Test.py>"), "Running dhclient")

--- a/test/posix/integration/syslog_plugin/test.py
+++ b/test/posix/integration/syslog_plugin/test.py
@@ -20,7 +20,7 @@ import platform
 if platform.system() == 'Darwin':
     subprocess.call(["sudo", "ifconfig", "bridge43", "alias", "10.0.0.2/24"])
 else:
-    subprocess.call(["sudo", "ifconfig", "bridge43:0", "10.0.0.2/24"])
+    subprocess.call(["sudo", "ip", "addr", "add", "10.0.0.2/24", "dev", "bridge43", "label", "bridge43:0"])
 
 # Tear down interface on exit
 @atexit.register
@@ -28,7 +28,7 @@ def tear_down():
     if platform.system() == 'Darwin':
         subprocess.call(["sudo", "ifconfig", "bridge43", "-alias", "10.0.0.2"])
     else:
-        subprocess.call(["sudo", "ifconfig", "bridge43:0", "down"])
+        subprocess.call(["sudo", "ip", "addr", "del", "10.0.0.2/24", "dev", "bridge43", "label", "bridge43:0"])
 
 UDP_IP = "10.0.0.2"
 UDP_PORT = 6514

--- a/test/posix/integration/tcp/test.py
+++ b/test/posix/integration/tcp/test.py
@@ -24,7 +24,7 @@ import platform
 if platform.system() == 'Darwin':
     subprocess.call(["sudo", "ifconfig", "bridge43", "alias", "10.0.0.4/24"])
 else:
-    subprocess.call(["sudo", "ifconfig", "bridge43:2", "10.0.0.4/24"])
+    subprocess.call(["sudo", "ip", "addr", "add", "10.0.0.4/24", "dev", "bridge43", "label", "bridge43:2"])
 
 # Tear down interface on exit
 @atexit.register
@@ -32,7 +32,7 @@ def tear_down():
     if platform.system() == 'Darwin':
         subprocess.call(["sudo", "ifconfig", "bridge43", "-alias", "10.0.0.4"])
     else:
-        subprocess.call(["sudo", "ifconfig", "bridge43:2", "down"])
+        subprocess.call(["sudo", "ip", "addr", "del", "10.0.0.4/24", "dev", "bridge43", "label", "bridge43:2"])
 
 
 S_HOST, S_PORT = '10.0.0.4', 4242

--- a/test/posix/integration/udp/test.py
+++ b/test/posix/integration/udp/test.py
@@ -20,7 +20,7 @@ import platform
 if platform.system() == 'Darwin':
     subprocess.call(["sudo", "ifconfig", "bridge43", "alias", "10.0.0.3/24"])
 else:
-    subprocess.call(["sudo", "ifconfig", "bridge43:1", "10.0.0.3/24"])
+    subprocess.call(["sudo", "ip", "addr", "add", "10.0.0.3/24", "dev", "bridge43", "label", "bridge43:1"])
 
 # Tear down interface on exit
 @atexit.register
@@ -28,7 +28,7 @@ def tear_down():
     if platform.system() == 'Darwin':
         subprocess.call(["sudo", "ifconfig", "bridge43", "-alias", "10.0.0.3"])
     else:
-        subprocess.call(["sudo", "ifconfig", "bridge43:1", "down"])
+        subprocess.call(["sudo", "ip", "addr", "del", "10.0.0.3/24", "dev", "bridge43", "label", "bridge43:1"])
 
 
 S_HOST, S_PORT = '10.0.0.3', 4242


### PR DESCRIPTION
- Now all integration tests should be fully iproute2 compliant. 
- Tests now run in random order
- Print timeout variable when it triggers