### PR TITLE
Bring openssl certificates into certs folder in service and fix bug in release mode with assert

### DIFF
--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -338,10 +338,14 @@ function(os_diskbuilder TARGET FOLD)
   os_build_memdisk(${TARGET} ${FOLD})
 endfunction()
 
-function(os_install_certificates FOLDER)
-  get_filename_component(REL_PATH "${FOLDER}" REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-  message(STATUS "Install certificate bundle at ${FOLDER}")
-  file(COPY ${INSTALL_LOC}/cert_bundle/ DESTINATION ${REL_PATH})
+function(os_add_ssl_certificates TARGET)
+  file(DOWNLOAD https://github.com/fwsGonzo/s2n_bundle/releases/download/v1/ca_bundle.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/certs.tgz)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/certs)
+  execute_process(
+    COMMAND tar -xvf  ${CMAKE_CURRENT_BINARY_DIR}/certs.tgz --strip-components=1 -C ${CMAKE_CURRENT_BINARY_DIR}/certs
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  os_build_memdisk(${TARGET} ${CMAKE_CURRENT_BINARY_DIR}/certs)
 endfunction()
 
 

--- a/src/net/openssl/client.cpp
+++ b/src/net/openssl/client.cpp
@@ -38,7 +38,9 @@ static void
 tls_private_key_for_ctx(SSL_CTX* ctx, int bits = 2048)
 {
   BIGNUM* bne = BN_new();
-  assert(BN_set_word(bne, RSA_F4) == 1);
+  auto res = BN_set_word(bne, RSA_F4);
+  assert(res == 1);
+  (void)res;
 
   RSA* rsa = RSA_new();
   int ret = RSA_generate_key_ex(rsa, bits, bne, NULL);


### PR DESCRIPTION
this added function in os.cmake allows you to add "standard" ceritifactes to a service