### PR TITLE
Jenkinsfile: Fix for version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
       steps {
         sh script: "ls -A | grep -v src | xargs rm -r || :", label: "Clean workspace"
         sh script: "conan config install https://github.com/includeos/conan_config.git", label: "conan config install"
-        script { VERSION = sh(script: "conan inspect -a version $SRC | cut -d ' ' -f 2", returnStdout: true).trim() }
+        script { VERSION = sh(script: "conan inspect -a version $SRC | grep version | cut -d ' ' -f 2", returnStdout: true).trim() }
       }
     }
     stage('Unit test and coverage') {


### PR DESCRIPTION
Turns out the first time we run `conan inspect` on a repo we get the following output:
```
Not
Trying
conanmanifest.txt
conanfile.py
version: 0.14.1-1184
```

So I had to do a little extra filtering. 
