### PR TITLE
More python2->3 changes

### DIFF
--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -1,4 +1,3 @@
-
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
@@ -6,16 +5,9 @@ endif()
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (${CMAKE_VERSION} VERSION_LESS "3.12")
-  find_program(Python2 python2.7)
-  if (NOT Python2)
-    #brutal fallback
-    set(Python2_EXECUTABLE python)
-  else()
-    set(Python2_EXECUTABLE ${Python2})
-  endif()
-else()
-  find_package(Python2 COMPONENTS Interpreter)
+find_program(PYTHON3_EXECUTABLE python3)
+if (PYTHON3_EXECUTABLE-NOTFOUND)
+  message(FATAL_ERROR "python3 not found")
 endif()
 
 if (NOT DEFINED PLATFORM)
@@ -297,7 +289,7 @@ function(os_add_memdisk TARGET DISK)
     REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
   add_custom_command(
     OUTPUT  memdisk.o
-    COMMAND ${Python2_EXECUTABLE} ${CONAN_RES_DIRS_INCLUDEOS}/tools/memdisk/memdisk.py --file memdisk.asm ${DISK_RELPATH}
+    COMMAND ${PYTHON3_EXECUTABLE} ${CONAN_RES_DIRS_INCLUDEOS}/tools/memdisk/memdisk.py --file memdisk.asm ${DISK_RELPATH}
     COMMAND nasm -f ${CMAKE_ASM_NASM_OBJECT_FORMAT} memdisk.asm -o memdisk.o
     DEPENDS ${DISK}
   )
@@ -367,7 +359,7 @@ function(os_add_nacl TARGET FILENAME)
   set(NACL_PATH ${CONAN_RES_DIRS_INCLUDEOS}/tools/NaCl)
   add_custom_command(
      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/nacl_content.cpp
-     COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME} | ${Python2_EXECUTABLE} ${NACL_PATH}/NaCl.py ${CMAKE_CURRENT_BINARY_DIR}/nacl_content.cpp
+     COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME} | ${PYTHON3_EXECUTABLE} ${NACL_PATH}/NaCl.py ${CMAKE_CURRENT_BINARY_DIR}/nacl_content.cpp
      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
    )
    add_library(nacl_content STATIC ${CMAKE_CURRENT_BINARY_DIR}/nacl_content.cpp)

--- a/src/memdisk/memdisk.py
+++ b/src/memdisk/memdisk.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+from builtins import str
 import sys
 import argparse
 from subprocess import call

--- a/test/fs/integration/fat16/test.py
+++ b/test/fs/integration/fat16/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/test/fs/integration/fat32/test.py
+++ b/test/fs/integration/fat32/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import sys
 import os

--- a/test/fs/integration/ide/test.py
+++ b/test/fs/integration/ide/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from builtins import str
 import sys

--- a/test/fs/integration/ide_write/test.py
+++ b/test/fs/integration/ide_write/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from builtins import str
 import sys

--- a/test/fs/integration/memdisk/test.py
+++ b/test/fs/integration/memdisk/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/fs/integration/vfs/test.py
+++ b/test/fs/integration/vfs/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from builtins import str
 import sys

--- a/test/fs/integration/virtio_block/test.py
+++ b/test/fs/integration/virtio_block/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from builtins import str
 import sys
 import subprocess

--- a/test/hw/integration/serial/test.py
+++ b/test/hw/integration/serial/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import sys

--- a/test/kernel/integration/LiveUpdate/test.py
+++ b/test/kernel/integration/LiveUpdate/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from builtins import str
 import sys
 import os

--- a/test/kernel/integration/block/test.py
+++ b/test/kernel/integration/block/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from builtins import str
 import sys
 import os

--- a/test/kernel/integration/context/test.py
+++ b/test/kernel/integration/context/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/kernel/integration/exception/test.py
+++ b/test/kernel/integration/exception/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from builtins import str
 import sys
 import os

--- a/test/kernel/integration/fiber/test.py
+++ b/test/kernel/integration/fiber/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/kernel/integration/grub/test.py
+++ b/test/kernel/integration/grub/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/kernel/integration/kprint/test.py
+++ b/test/kernel/integration/kprint/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import division
 from __future__ import print_function

--- a/test/kernel/integration/memmap/test.py
+++ b/test/kernel/integration/memmap/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/kernel/integration/modules/test.py
+++ b/test/kernel/integration/modules/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/test/kernel/integration/paging/test.py
+++ b/test/kernel/integration/paging/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from builtins import str
 import sys

--- a/test/kernel/integration/plugin_init/test.py
+++ b/test/kernel/integration/plugin_init/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from builtins import str
 import sys
 import os

--- a/test/kernel/integration/rng/test.py
+++ b/test/kernel/integration/rng/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/kernel/integration/smp/test.py
+++ b/test/kernel/integration/smp/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/kernel/integration/term/test.py
+++ b/test/kernel/integration/term/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from builtins import str
 import sys

--- a/test/kernel/integration/timers/test.py
+++ b/test/kernel/integration/timers/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/kernel/integration/tls/test.py
+++ b/test/kernel/integration/tls/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from builtins import str
 import sys
 import os

--- a/test/mod/integration/gsl/test.py
+++ b/test/mod/integration/gsl/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/net/integration/bufstore/test.py
+++ b/test/net/integration/bufstore/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/net/integration/configure/test.py
+++ b/test/net/integration/configure/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/net/integration/dhclient/test.py
+++ b/test/net/integration/dhclient/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/net/integration/dhcpd/test.py
+++ b/test/net/integration/dhcpd/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/net/integration/dhcpd_dhclient_linux/test.py
+++ b/test/net/integration/dhcpd_dhclient_linux/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/net/integration/dns/test.py
+++ b/test/net/integration/dns/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/net/integration/gateway/test.py
+++ b/test/net/integration/gateway/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/net/integration/http/test.py
+++ b/test/net/integration/http/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from future import standard_library
 standard_library.install_aliases()

--- a/test/net/integration/icmp/test.py
+++ b/test/net/integration/icmp/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/net/integration/icmp6/test.py
+++ b/test/net/integration/icmp6/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/net/integration/microLB/test.py
+++ b/test/net/integration/microLB/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()

--- a/test/net/integration/nat/test.py
+++ b/test/net/integration/nat/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/net/integration/router/test.py
+++ b/test/net/integration/router/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from future import standard_library

--- a/test/net/integration/router6/test.py
+++ b/test/net/integration/router6/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from future import standard_library

--- a/test/net/integration/slaac/test.py
+++ b/test/net/integration/slaac/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/net/integration/tcp/debug.py
+++ b/test/net/integration/tcp/debug.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import socket
 import sys

--- a/test/net/integration/tcp/test.py
+++ b/test/net/integration/tcp/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/net/integration/udp/test.py
+++ b/test/net/integration/udp/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/net/integration/vlan/test.py
+++ b/test/net/integration/vlan/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/net/integration/websocket/test.py
+++ b/test/net/integration/websocket/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from future import standard_library

--- a/test/plugin/integration/unik/test.py
+++ b/test/plugin/integration/unik/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/posix/integration/conf/test.py
+++ b/test/posix/integration/conf/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/posix/integration/file_fd/test.py
+++ b/test/posix/integration/file_fd/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/posix/integration/main/test.py
+++ b/test/posix/integration/main/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from builtins import str
 import sys

--- a/test/posix/integration/pthread/test.py
+++ b/test/posix/integration/pthread/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/posix/integration/stat/test.py
+++ b/test/posix/integration/stat/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/posix/integration/syslog_default/test.py
+++ b/test/posix/integration/syslog_default/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/posix/integration/syslog_plugin/test.py
+++ b/test/posix/integration/syslog_plugin/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from builtins import str
 import sys

--- a/test/posix/integration/tcp/test.py
+++ b/test/posix/integration/tcp/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from future import standard_library

--- a/test/posix/integration/udp/test.py
+++ b/test/posix/integration/udp/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from future import standard_library

--- a/test/posix/integration/utsname/test.py
+++ b/test/posix/integration/utsname/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/stl/integration/coroutines/test.py
+++ b/test/stl/integration/coroutines/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from builtins import str
 import sys
 import os

--- a/test/stl/integration/crt/test.py
+++ b/test/stl/integration/crt/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from builtins import str
 import sys

--- a/test/stl/integration/exceptions/test.py
+++ b/test/stl/integration/exceptions/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/stl/integration/stl/test.py
+++ b/test/stl/integration/stl/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from builtins import str
 import sys
 import os

--- a/test/stress/test.py
+++ b/test/stress/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import division
 from __future__ import print_function
 from builtins import str

--- a/test/util/integration/tar/test.py
+++ b/test/util/integration/tar/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str

--- a/test/util/integration/tar_gz/test.py
+++ b/test/util/integration/tar_gz/test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 from builtins import str


### PR DESCRIPTION
- change `os.cmake` to only look for python3 executable.
- Futurize the `memdisk.py` script
- Change shebang to python3 in all test scripts. 