### PR TITLE
LiveUpdate: Req for building LiveUpdate on MacOS

### DIFF
--- a/lib/LiveUpdate/CMakeLists.txt
+++ b/lib/LiveUpdate/CMakeLists.txt
@@ -52,6 +52,9 @@ add_definitions(-DARCH_${ARCH})
 add_definitions(-DARCH="${ARCH}")
 add_definitions(-DPLATFORM_${PLATFORM})
 
+set(TRIPLE "${ARCH}-pc-linux-elf")
+set(CMAKE_CXX_COMPILER_TARGET ${TRIPLE})
+set(CMAKE_C_COMPILER_TARGET ${TRIPLE})
 
 add_custom_command(
   PRE_BUILD


### PR DESCRIPTION
Added after ARCH definitions:
```
set(TRIPLE "${ARCH}-pc-linux-elf")
set(CMAKE_CXX_COMPILER_TARGET ${TRIPLE})
set(CMAKE_C_COMPILER_TARGET ${TRIPLE})
```