### PR TITLE
Dhcpd client linux test back in business

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -106,10 +106,9 @@ set(TEST_LIST
   #TODO move websocket to http library
   "websocket" "20"    "net"
 
-  #TODO add a cmake variable to exclude these ?
   "dhclient" "20" "net"
   "dhcpd" "20" "net"
-  #dhcpd_dhclient_linux
+  "dhcpd_dhclient_linux" "60" "net"
 
   "block"     "40" "kernel"
   ##TODO check if context test is old and should be removed!!

--- a/test/net/integration/dhcpd_dhclient_linux/CMakeLists.txt
+++ b/test/net/integration/dhcpd_dhclient_linux/CMakeLists.txt
@@ -1,35 +1,21 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.0)
 
-# IncludeOS install location
-if (NOT DEFINED ENV{INCLUDEOS_PREFIX})
-  set(ENV{INCLUDEOS_PREFIX} /usr/local)
+#service
+project (dhclient_linux)
+if (NOT DEFINED CONAN_DEPENDENCIES)
+  include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake OPTIONAL RESULT_VARIABLE HAS_CONAN)
+  if (NOT HAS_CONAN)
+    message(FATAL_ERROR "missing conanbuildinfo.cmake did you forget to run conan install ?")
+  endif()
 endif()
+conan_basic_setup()
 
-include($ENV{INCLUDEOS_PREFIX}/includeos/pre.service.cmake)
+include(os)
 
-project(test_dhcp_server_dhclient)
+os_add_executable(net_dhcpd_dhclient_linux "IncludeOS DHCP server test"  service.cpp)
 
-# Human-readable name of your service
-set(SERVICE_NAME "IncludeOS DHCP server test with Linux dhclient")
-
-# Name of your service binary
-set(BINARY       "test_dhcp_server_dhclient")
-
-# Maximum memory can be hard-coded into the binary
-set(MAX_MEM 128)
-
-# Source files to be linked with OS library parts to form bootable image
-set(SOURCES
-    service.cpp
-  )
-
-# DRIVERS / PLUGINS:
-
-set(DRIVERS
-  virtionet
-  )
-
-# include service build script
-include($ENV{INCLUDEOS_PREFIX}/includeos/post.service.cmake)
+os_add_plugins(net_dhcpd_dhclient_linux autoconf)
+os_add_drivers(net_dhcpd_dhclient_linux virtionet)
+os_add_stdout(net_dhcpd_dhclient_linux default_stdout)
 
 configure_file(test.py ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/net/integration/dhcpd_dhclient_linux/CMakeLists.txt
+++ b/test/net/integration/dhcpd_dhclient_linux/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.0)
 
 #service
-project (dhclient_linux)
+project (service)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake OPTIONAL RESULT_VARIABLE HAS_CONAN)
+if (NOT HAS_CONAN)
+  message(FATAL_ERROR "missing conanbuildinfo.cmake did you forget to run conan install ?")
+endif()
+conan_basic_setup()
+
 if (NOT DEFINED CONAN_DEPENDENCIES)
   include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake OPTIONAL RESULT_VARIABLE HAS_CONAN)
   if (NOT HAS_CONAN)

--- a/test/net/integration/dhcpd_dhclient_linux/service.cpp
+++ b/test/net/integration/dhcpd_dhclient_linux/service.cpp
@@ -39,6 +39,7 @@ void Service::start(const std::string&)
   IP4::addr pool_start{10,200,100,20};
   IP4::addr pool_end{10,200,100,30};
   server = std::make_unique<DHCPD>(inet.udp(), pool_start, pool_end);
+  server->listen();
 
   INFO("<Service>", "Service started");
 }

--- a/test/net/integration/dhcpd_dhclient_linux/test.py
+++ b/test/net/integration/dhcpd_dhclient_linux/test.py
@@ -80,7 +80,7 @@ def ping_test():
     cleanup()
 
 def run_dhclient(trigger_line):
-  route_output = subprocess.check_output(["route"])
+  route_output = subprocess.check_output(["route"]).decode("utf-8")
 
   if "10.0.0.0" not in route_output:
     subprocess.call(["sudo", "ip", "link", "set", "dev", "bridge43", "up"], timeout=thread_timeout)
@@ -103,7 +103,7 @@ def run_dhclient(trigger_line):
     print(dhclient)
 
     # gets ip of dhclient used to ping
-    check_dhclient_output(dhclient)
+    check_dhclient_output(dhclient.decode("utf-8"))
 
   except subprocess.CalledProcessError as exception:
     print(color.FAIL("<Test.py> dhclient FAILED threw exception:"))

--- a/test/net/integration/dhcpd_dhclient_linux/test.py
+++ b/test/net/integration/dhcpd_dhclient_linux/test.py
@@ -10,15 +10,11 @@ import subprocess
 thread_timeout = 20
 
 from threading import Timer
-
-includeos_src = os.environ.get('INCLUDEOS_SRC',
-                               os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__))).split('/test')[0])
-sys.path.insert(0,includeos_src)
-
 from vmrunner import vmrunner
 import socket
-
 from vmrunner.prettify import color
+
+thread_timeout = 40
 
 # Get an auto-created VM from the vmrunner
 vm = vmrunner.vms[0]
@@ -126,4 +122,7 @@ def run_dhclient(trigger_line):
 vm.on_output("Service started", run_dhclient)
 
 # Boot the VM, taking a timeout as parameter
-vm.cmake().boot(thread_timeout).clean()
+if len(sys.argv) > 1:
+    vmrunner.vms[0].boot(image_name=str(sys.argv[1]))
+else:
+    vm.cmake().boot(thread_timeout).clean()

--- a/test/net/integration/dhcpd_dhclient_linux/vm.json
+++ b/test/net/integration/dhcpd_dhclient_linux/vm.json
@@ -1,6 +1,10 @@
 {
-  "image" : "test_dhcp_server_dhclient.img",
-  "net" : [{"device" : "virtio", "mac" : "c0:01:0a:00:00:2a"}],
-  "mem" : 128,
-  "intrusive" : "True"
+  "image": "test_dhcp_server_dhclient.img",
+  "net": [
+    {
+      "device": "virtio",
+      "mac": "c0:01:0a:00:00:2a"
+    }
+  ],
+  "mem": 128
 }


### PR DESCRIPTION
Seems the only thing wrong with the test was the missing: `server->listen();` 
No point in merging this before #2155 is merged. The test will not actually run before then. 