### PR TITLE
travis-ci: build for linux with clang-6.0 x86_64 on macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ before_cache:
   - brew cleanup
 
 cache:
-  ccache: true
   - directories:
     - $HOME/Library/Caches/Homebrew
-    
+
 jobs:
   include:
     - script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+os: osx
+osx_image: xcode10.2
+compiler:
+  - clang
+  - gcc
+
+addons:
+  homebrew:
+    packages:
+    - cmake
+    - conan
+    - nasm
+    - llvm@6
+
+jobs:
+  include:
+    - script:
+        - export CC=/usr/local/opt/llvm\@6/bin/clang
+        - export CXX=/usr/local/opt/llvm\@6/bin/clang++
+        - echo "BUILDING KERNEL"
+        - conan create . includeos/latest -pr clang-6.0-macos-x86_64
+        - echo "BUILDING LiveUpdate"
+        - conan create lib/LiveUpdate includeos/latest -pr clang-6.0-macos-x86_64
+      name: "clang-6.0-x86_64"
+
+before_install:
+  - git fetch --tags https://github.com/includeos/IncludeOS.git
+
+install:
+  - conan config install https://github.com/includeos/conan_config.git
+  - conan --version
+  - clang --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ osx_image: xcode10.2
 compiler:
   - clang
   - gcc
+  - python
 
 addons:
   homebrew:
@@ -26,6 +27,18 @@ jobs:
         - conan create . includeos/latest -pr clang-6.0-macos-x86_64
         - echo "BUILDING LiveUpdate"
         - conan create lib/LiveUpdate includeos/latest -pr clang-6.0-macos-x86_64
+        - conan install hello_world -pr clang-6.0-macos-x86_64
+        - source activate.sh
+        - cmake hello_world
+        - cmake --build .
+        - gtimeout 7 boot hello > hello_log.txt || true
+        - |
+          if grep -F "Running [ Hello world - OS included ]" hello_log.txt
+          then
+            echo "Hello World -  Success! :)"
+          else
+            echo "Failed :("
+          fi
       name: "clang-6.0-x86_64"
 
 before_install:
@@ -35,3 +48,10 @@ install:
   - conan config install https://github.com/includeos/conan_config.git
   - conan --version
   - clang --version
+  - pip install future
+
+before_script:
+  - git clone https://github.com/includeos/hello_world
+
+after_script:
+  - source deactivate.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ addons:
     - nasm
     - llvm@6
 
+before_cache:
+  - brew cleanup
+
+cache:
+  ccache: true
+  - directories:
+    - $HOME/Library/Caches/Homebrew
+    
 jobs:
   include:
     - script:
@@ -21,14 +29,6 @@ jobs:
         - conan create lib/LiveUpdate includeos/latest -pr clang-6.0-macos-x86_64
       name: "clang-6.0-x86_64"
 
-before_cache:
-  - brew cleanup
-
-cache:
-  ccache: true
-  - directories:
-    - $HOME/Library/Caches/Homebrew
-    
 before_install:
   - git fetch --tags https://github.com/includeos/IncludeOS.git
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ addons:
 jobs:
   include:
     - script:
-        - export CC=/usr/local/opt/llvm\@6/bin/clang
-        - export CXX=/usr/local/opt/llvm\@6/bin/clang++
         - echo "BUILDING KERNEL"
         - conan create . includeos/latest -pr clang-6.0-macos-x86_64
         - echo "BUILDING LiveUpdate"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,14 @@ jobs:
         - conan create lib/LiveUpdate includeos/latest -pr clang-6.0-macos-x86_64
       name: "clang-6.0-x86_64"
 
+before_cache:
+  - brew cleanup
+
+cache:
+  ccache: true
+  - directories:
+    - $HOME/Library/Caches/Homebrew
+    
 before_install:
   - git fetch --tags https://github.com/includeos/IncludeOS.git
 


### PR DESCRIPTION
Building same version of IncludeOS kernel and LiveUpdate for Linux on **MacOS**:
profile: `clang-6.0-macos-x86_64`
arch: `x86_64`
compiler: `clang-6.0`
