### PR TITLE
tcp: Handle FIN delayed if packet loss

### DIFF
--- a/api/net/tcp/connection.hpp
+++ b/api/net/tcp/connection.hpp
@@ -681,6 +681,9 @@ private:
 
   Recv_window_getter recv_wnd_getter;
 
+  seq_t fin_seq_ = 0;
+  bool fin_recv_ = false;
+
   bool close_signaled_ = false;
 
   /** Number of retransmission attempts on the packet first in RT-queue */
@@ -780,6 +783,12 @@ private:
   */
   void receive_disconnect();
 
+  void update_fin(const Packet_view& pkt);
+
+  bool should_handle_fin() const noexcept
+  { return fin_recv_ and static_cast<int32_t>(fin_seq_ - cb.RCV.NXT) == 0; }
+
+  void handle_fin();
 
   /// --- WRITING --- ///
 

--- a/api/net/tcp/connection.hpp
+++ b/api/net/tcp/connection.hpp
@@ -1212,6 +1212,9 @@ private:
   */
   void add_option(Option::Kind, Packet_view&);
 
+  void add_syn_options(Packet_view& pkt);
+  void add_synack_options(Packet_view& pkt);
+
 
 }; // < class Connection
 

--- a/src/net/tcp/connection.cpp
+++ b/src/net/tcp/connection.cpp
@@ -1461,7 +1461,7 @@ void Connection::add_synack_options(Packet_view& packet)
   if(cb.SND.wind_shift > 0)
   {
     add_option(Option::WS, packet);
-    //packet.set_win(std::min((uint32_t)default_window_size, tcb.RCV.WND));
+    packet.set_win(std::min((uint32_t)default_window_size, cb.RCV.WND));
   }
   // SACK permitted
   if(sack_perm == true)

--- a/src/net/tcp/connection.cpp
+++ b/src/net/tcp/connection.cpp
@@ -1018,11 +1018,17 @@ void Connection::retransmit() {
     packet->set_flag(ACK);
   }
   // If retransmission from either SYN-SENT or SYN-RCV, add SYN
-  if(UNLIKELY(is_state(SynSent::instance()) or is_state(SynReceived::instance())))
+  if(UNLIKELY(is_state(SynSent::instance())))
   {
     packet->set_flag(SYN);
-    packet->set_seq(cb.SND.UNA);
     syn_rtx_++;
+    add_syn_options(*packet);
+  }
+  else if(UNLIKELY(is_state(SynReceived::instance())))
+  {
+    packet->set_flag(SYN);
+    syn_rtx_++;
+    add_synack_options(*packet);
   }
   // If not, check if there is data and retransmit
   else if(writeq.size())
@@ -1417,6 +1423,53 @@ void Connection::add_option(Option::Kind kind, Packet_view& packet) {
   default:
     break;
   }
+}
+
+void Connection::add_syn_options(Packet_view& packet)
+{
+  Expects(packet.isset(SYN));
+  Expects(not packet.isset(ACK));
+  // Always MSS
+  add_option(Option::MSS, packet);
+
+  // Window scaling
+  if(uses_window_scaling())
+  {
+    add_option(Option::WS, packet);
+    //packet.set_win(std::min((uint32_t)default_window_size, cb.RCV.WND));
+  }
+  // Add timestamps
+  if(uses_timestamps())
+  {
+    add_option(Option::TS, packet);
+  }
+  // Use SACK
+  if(uses_SACK())
+  {
+    add_option(Option::SACK_PERM, packet);
+  }
+}
+
+void Connection::add_synack_options(Packet_view& packet)
+{
+  Expects(packet.isset(SYN));
+  Expects(packet.isset(ACK));
+  // Always MSS
+  add_option(Option::MSS, packet);
+
+  // This means WS was accepted in the SYN packet
+  if(cb.SND.wind_shift > 0)
+  {
+    add_option(Option::WS, packet);
+    //packet.set_win(std::min((uint32_t)default_window_size, tcb.RCV.WND));
+  }
+  // SACK permitted
+  if(sack_perm == true)
+  {
+    add_option(Option::SACK_PERM, packet);
+  }
+
+  // NOTE: Timestamp is already handled by create_outgoing_packet
 }
 
 bool Connection::uses_window_scaling() const noexcept


### PR DESCRIPTION
FIN can now be processed later than when it was received if there are holes in the recv window.