### PR TITLE
Fix broken nix-build, might  as well go to clang7

### DIFF
--- a/api/hw/msi.hpp
+++ b/api/hw/msi.hpp
@@ -4,6 +4,7 @@
 #define HW_MSI_HPP
 
 #include <cstdint>
+#include <cstddef>
 #include <cassert>
 #include <vector>
 

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,6 @@
 # Author: Bjørn Forsman <bjorn.forsman@gmail.com>
 
 { nixpkgs ?
-  # branch nixos-20.09 @ 2021-02-20
   builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz"
 
 , pkgs ? import nixpkgs { config = {}; overlays = []; }
@@ -17,7 +16,15 @@
 with pkgs;
 
 let
-  stdenv = clang6Stdenv;
+  stdenv = clang7Stdenv;
+
+  # Get older dependencies from here
+  # TODO: Looks like it's only GSL 4.0.0 we're choking on so we can probably just update that.
+  nix_20_09 = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/38eaa62f28384bc5f6c394e2a99bd6a4913fc71f.tar.gz";
+  }) {};
+
+
   uzlib = stdenv.mkDerivation rec {
     pname = "uzlib";
 
@@ -238,7 +245,7 @@ let
     buildInputs = [
       botan2
       http-parser
-      microsoft_gsl
+      nix_20_09.microsoft_gsl
       openssl
       rapidjson
       s2n-tls

--- a/src/crt/quick_exit.cpp
+++ b/src/crt/quick_exit.cpp
@@ -10,7 +10,7 @@ void __default_quick_exit() {
 // According to the standard this should probably be a list or vector.
 static void (*__quick_exit_func)() = __default_quick_exit;
 
-int at_quick_exit (void (*func)())
+int at_quick_exit (void (*func)()) noexcept
 {
   // Append to the ist
   __quick_exit_func = func;

--- a/src/kernel/cpuid.cpp
+++ b/src/kernel/cpuid.cpp
@@ -1,9 +1,9 @@
-
 #include <kernel/cpuid.hpp>
 #include <cstring>
 #include <cstdint>
 #include <array>
 #include <unordered_map>
+#include <stdexcept>
 
 namespace std
 {

--- a/src/plugins/field_medic/fieldmedic.hpp
+++ b/src/plugins/field_medic/fieldmedic.hpp
@@ -10,6 +10,7 @@
 **/
 
 #include <array>
+#include <stdexcept>
 
 namespace medic{
   namespace diag


### PR DESCRIPTION
This fixes the `nix-build` for me. Some missing includes, and it chokes on GSL4. We can probably just fix that, but we don't need span from GSL now that it's part of the standard, so I'm making a task for that too. 