### PR TITLE
Build musl for IncludeOS with nix and clang

### DIFF
--- a/deps/musl/default.nix
+++ b/deps/musl/default.nix
@@ -1,0 +1,49 @@
+{ nixpkgs ?
+  builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz"
+, pkgs ? import nixpkgs { config = {}; overlays = []; }
+}:
+with pkgs;
+let
+  stdenv = clang7Stdenv;
+  musl-includeos=stdenv.mkDerivation rec {
+    pname = "musl-includeos";
+    version = "1.1.18";
+
+    src = fetchGit {
+      url = "git://git.musl-libc.org/musl";
+      rev = "eb03bde2f24582874cb72b56c7811bf51da0c817";
+    };
+
+    nativeBuildInputs = [ git clang tree];
+
+    patches = [
+      ./patches/musl.patch
+      ./patches/endian.patch
+    ];
+
+    postUnpack = ''
+      echo "Replacing musl's syscall headers with IncludeOS syscalls"
+
+      cp ${./patches/includeos_syscalls.h} $sourceRoot/src/internal/includeos_syscalls.h
+      cp ${./patches/syscall.h} $sourceRoot/src/internal/syscall.h
+
+      rm $sourceRoot/arch/x86_64/syscall_arch.h
+      rm $sourceRoot/arch/i386/syscall_arch.h
+      '';
+
+   configurePhase = ''
+      echo "Configuring with musl's configure script"
+      ./configure --prefix=$out --disable-shared --enable-debug
+      '';
+
+    CFLAGS = "-Wno-error=int-conversion -nostdinc";
+
+    meta = {
+      description = "musl - an implementation of the standard library for Linux-based systems";
+      homepage = "https://www.musl-libc.org/";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ includeos ];
+    };
+  };
+in
+musl-includeos

--- a/deps/musl/default.nix
+++ b/deps/musl/default.nix
@@ -8,7 +8,7 @@
 with pkgs;
 let
   stdenv = clang7Stdenv;
-  musl-includeos=stdenv.mkDerivation rec {
+  musl-includeos = stdenv.mkDerivation rec {
     pname = "musl-includeos";
     version = "1.1.18";
 
@@ -32,20 +32,19 @@ let
 
       rm $sourceRoot/arch/x86_64/syscall_arch.h
       rm $sourceRoot/arch/i386/syscall_arch.h
-      '';
+    '';
 
    configurePhase = ''
       echo "Configuring with musl's configure script"
       ./configure --prefix=$out --disable-shared --enable-debug
-      '';
+    '';
 
     CFLAGS = "-Wno-error=int-conversion -nostdinc";
 
     meta = {
-      description = "musl - an implementation of the standard library for Linux-based systems";
+      description = "musl - Linux based libc, built with IncludeOS linux-like syscalls";
       homepage = "https://www.musl-libc.org/";
       license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [ includeos ];
     };
   };
 in

--- a/deps/musl/default.nix
+++ b/deps/musl/default.nix
@@ -1,5 +1,8 @@
 { nixpkgs ?
-  builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz"
+  builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz";
+    sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
+  }
 , pkgs ? import nixpkgs { config = {}; overlays = []; }
 }:
 with pkgs;


### PR DESCRIPTION
Should build a useable musl for includeos with `nix-build` from `IncludeOS/deps/musl`