### PR TITLE
Nix static wip - part 2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,22 +7,7 @@
 #
 # Authors: Bjørn Forsman <bjorn.forsman@gmail.com>
 
-{ nixpkgs ? <nixpkgs>, # Builds cleanly with unstable, May 9. 2024
-
-  # TODO: We want to pin nixpkgs, but:
-  #
-  # builtins.fetchTarball {
-  #
-  # This👇 "is not able to compile a simple test program" (clang via cmake)
-  #  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05-pre.tar.gz";
-  #  sha256 = "1cfbkahcfj1hgh4v5nfqwivg69zks8d72n11m5513i0phkqwqcgh";
-
-  # This👇 "is not able to compile a simple test program" (clang via cmake)
-  # url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz";
-  # sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
-  #
-  #},
-
+{ nixpkgs ? ./pinned.nix, # Builds cleanly May 9. 2024
   pkgs ? (import nixpkgs { }).pkgsStatic,
 
   # This env has musl and LLVM's libc++ as static libraries.
@@ -107,6 +92,7 @@ let
       inherit botan2;
       #inherit s2n-tls;
       inherit musl-includeos;
+      inherit cmake;
     };
 
     meta = {

--- a/default.nix
+++ b/default.nix
@@ -5,15 +5,28 @@
 #
 # $ nix-build ./path/to/this/file.nix
 #
-# Author: Bjørn Forsman <bjorn.forsman@gmail.com>
+# Authors: Bjørn Forsman <bjorn.forsman@gmail.com>
 
-{ nixpkgs ?
-  builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz";
-    sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
-  },
-  pkgs ? (import nixpkgs { }).pkgsStatic, # should we add pkgsStatic here? Fails on cmake
-  stdenv ? pkgs.llvmPackages_7.stdenv
+{ nixpkgs ? <nixpkgs>, # Builds cleanly with unstable, May 9. 2024
+
+  # TODO: We want to pin nixpkgs, but:
+  #
+  # builtins.fetchTarball {
+  #
+  # This👇 "is not able to compile a simple test program" (clang via cmake)
+  #  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05-pre.tar.gz";
+  #  sha256 = "1cfbkahcfj1hgh4v5nfqwivg69zks8d72n11m5513i0phkqwqcgh";
+
+  # This👇 "is not able to compile a simple test program" (clang via cmake)
+  # url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz";
+  # sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
+  #
+  #},
+
+  pkgs ? (import nixpkgs { }).pkgsStatic,
+
+  # This env has musl and LLVM's libc++ as static libraries.
+  stdenv ? pkgs.llvmPackages_16.libcxxStdenv
 }:
 
 assert (stdenv.buildPlatform.isLinux == false) ->
@@ -22,7 +35,6 @@ assert (stdenv.hostPlatform.isMusl == false) ->
   throw "Stdenv should be based on Musl";
 
 let
-
   musl-includeos = pkgs.callPackage ./deps/musl/default.nix { inherit nixpkgs stdenv pkgs; };
   uzlib = pkgs.callPackage ./deps/uzlib/default.nix { inherit stdenv pkgs; };
   botan2 = pkgs.callPackage ./deps/botan/default.nix { inherit pkgs; };
@@ -58,13 +70,32 @@ let
     ];
 
     buildInputs = [
-      musl-includeos
+
+      # TODO:
+      # including musl here makes the compiler pick up musl's libc headers
+      # before libc++'s libc headers, which doesn't work. See e.g. <cstdint>
+      # line 149;
+      # error <cstdint> tried including <stdint.h> but didn't find libc++'s <stdint.h> header.
+      # #ifndef _LIBCPP_STDINT_H
+      #   error <cstdint> tried including <stdint.h> but didn't find libc++'s <stdint.h> header. \
+      #   This usually means that your header search paths are not configured properly. \
+      #   The header search paths should contain the C++ Standard Library headers before \
+      #   any C Standard Library, and you are probably using compiler flags that make that \
+      #   not be the case.
+      # #endif
+      #
+      # With this commented out IncludeOS builds with Nix libc++, which is great,
+      # but might bite us later because it then uses a libc we didn't patch.
+      # Best case we case we can adapt our own musl to be identical, use nix static
+      # musl for compilation, and includeos-musl only for linking.
+      #
+      # musl-includeos  👈 this has to come in after libc++ headers.
       botan2
       http-parser
       microsoft_gsl
       pkgs.openssl
       pkgs.rapidjson
-      #s2n-tls
+      #s2n-tls          👈 This is postponed until we can fix the s2n build.
       uzlib
     ];
 

--- a/pinned.nix
+++ b/pinned.nix
@@ -1,0 +1,24 @@
+import (
+  builtins.fetchTarball {
+    #
+    # Pinned to nixpkgs-unstable, commit bcd44e2 from May 1st. 2024:
+    # https://github.com/NixOS/nixpkgs/commit/bcd44e224fd68ce7d269b4f44d24c2220fd821e7
+    #
+    # Fetched from nixpkgs-unstable branch May 9th. 2024 (Ascension day)
+    # Found the hash in /nix/var/nix/profiles/per-user/root/channels/nixpkgs/.git-revision
+    #
+    url = "https://github.com/nixos/nixpkgs/archive/bcd44e224fd68ce7d269b4f44d24c2220fd821e7.tar.gz";
+    sha256 = "1dd8x811mkm0d89b0yy0cgv28g343bnid0xn2psd3sk1nkgx9g9j";
+
+    # TODO: We want to pin to a nixpkgs release branch, but:
+    #
+    # This👇 "is not able to compile a simple test program" (clang via cmake)
+    # url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05-pre.tar.gz";
+    # sha256 = "1cfbkahcfj1hgh4v5nfqwivg69zks8d72n11m5513i0phkqwqcgh";
+
+    # This👇 "is not able to compile a simple test program" (clang via cmake)
+    # url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz";
+    # sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
+    #
+  }
+)

--- a/src/crt/quick_exit.cpp
+++ b/src/crt/quick_exit.cpp
@@ -10,7 +10,7 @@ void __default_quick_exit() {
 // According to the standard this should probably be a list or vector.
 static void (*__quick_exit_func)() = __default_quick_exit;
 
-int at_quick_exit (void (*func)()) noexcept
+int at_quick_exit (void (*func)())
 {
   // Append to the ist
   __quick_exit_func = func;

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -6,7 +6,8 @@ if(${ARCH} STREQUAL "x86_64")
     openssl/tls_stream.cpp
     https/openssl_server.cpp
     http/client.cpp
-    https/s2n_server.cpp
+    # TODO: Fix s2n build issues and move to their own repo.
+    # https/s2n_server.cpp
   )
   #TODO get from conan
   set(OPENSSL_LIBS

--- a/src/posix/file_fd.cpp
+++ b/src/posix/file_fd.cpp
@@ -2,8 +2,8 @@
 #include <posix/file_fd.hpp>
 #include <errno.h>
 #include <dirent.h>
+#include <limits.h>
 #include <sys/uio.h>
-#include <bits/xopen_lim.h>
 
 ssize_t File_FD::read(void* p, size_t n)
 {


### PR DESCRIPTION
Thanks to @MagnusS IncludeOS now compiles with nix using musl 🎉  

And, a static nix-build of LLVM's libc++. I'm looking into whether we can link against that as-is, without rolling our own build of LLVM at all.

While we build our own musl-includeos (disabled in the most recent commit) the musl from nixpkgs is the one in use during compilation for now. See for example, this issue, now fixed, where it references `musl-static-x86_64-unknown-linux-musl-1.2.3`, which is quite recent compared to the 1.1.18 musl-includeos is pinned to.
```                                                                                                                                  
/build/source/src/crt/quick_exit.cpp:13:5: error: exception specification in declaration does not match previous declaration         
int at_quick_exit (void (*func)()) noexcept                                                                                          
    ^                                                                                                                                
/nix/store/6gc6xiawd9xcvscd6p0wcjcm8b42fmwh-musl-static-x86_64-unknown-linux-musl-1.2.3-dev/include/stdlib.h:50:5: note: previous de\
claration is here                                                                                                                    
int at_quick_exit (void (*) (void));                                                                                                 
``` 
So we should expect some incompatibilities with musl-includeos when we get to linking a bootable binary, where we absolutely have to have our own libc, because we need to patch in our own system calls. 

In the best case we can compile IncludeOS itself against the existing musl package, and then only use our own when linking the bootable binary. This would make our build setup simpler and easier to maintain, avoiding the need for `-nostdinc` when compiling IncludeOS. Worst case we'll need to make our own nix build of libcxx, libunwind and friends, to compile them and the IncludeOS libs against musl-includeos.

Anyway, this setup is much closer to something working than what's in at the moment so if a clean build can be reproduced I think we should merge.

```
alfredb@uniperf-builder:~/IncludeOS$ tree result/lib/
result/lib/
├── libarch.a
├── libmusl_syscalls.a
└── libos.a

0 directories, 3 files
alfredb@uniperf-builder:~/IncludeOS$ tree result/drivers/
result/drivers/
├── libboot_logger.a
├── libe1000.a
├── libip4_reassembly.a
├── libtimestamps.a
├── libvga_emergency.a
├── libvirtioblk.a
├── libvirtiocon.a
├── libvirtionet.a
├── libvmxnet3.a
└── stdout
    ├── libdefault_stdout.a
    └── libvga_output.a

1 directory, 11 files
alfredb@uniperf-builder:~/IncludeOS$ tree result/platform/
result/platform/
└── libx86_64_pc.a

0 directories, 1 file
alfredb@uniperf-builder:~/IncludeOS$ tree result/plugins/
result/plugins/
├── libautoconf.a
├── libexample.a
├── libfield_medic.a
├── libmadness.a
├── libnacl.a
├── libsyslog.a
├── libsyslogd.a
├── libsystem_log.a
├── libterminal.a
├── libunik.a
└── libvfs.a
```
