### PR TITLE
Revert "tools: Remove vmbuild"

### DIFF
--- a/vmbuild/.gitignore
+++ b/vmbuild/.gitignore
@@ -1,0 +1,2 @@
+elf_syms
+vmbuild

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+project (vmbuilder)
+
+include(CheckCXXCompilerFlag)
+set(CMAKE_BUILD_TYPE Release)
+check_cxx_compiler_flag(-std=c++14 HAVE_FLAG_STD_CXX14)
+if(NOT HAVE_FLAG_STD_CXX14)
+ message(FATAL_ERROR "The provided compiler: " ${CMAKE_CXX_COMPILER} "\n does not support c++14 standard please make sure your CC and CXX points to a compiler that supports c++14")
+endif()
+
+set(SOURCES vmbuild.cpp)
+set(ELF_SYMS_SOURCES elf_syms.cpp ../src/util/crc32.cpp)
+
+
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O2 -g")
+
+
+if(CONAN_EXPORTED) # in conan local cache
+  # standard conan installation, deps will be defined in conanfile.py
+  # and not necessary to call conan again, conan is already running
+  include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
+  conan_basic_setup()
+else()
+  if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+     message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+     file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/master/conan.cmake"
+                    "${CMAKE_BINARY_DIR}/conan.cmake")
+  endif()
+  ##needed by conaningans
+
+  include(${CMAKE_BINARY_DIR}/conan.cmake)
+  conan_cmake_run(
+    REQUIRES GSL/2.0.0@includeos/test
+    BASIC_SETUP
+  )
+endif(CONAN_EXPORTED)
+#TODO pull vmbuild conanfile.py inn when not building with conan to get deps
+# TODO: write scripts that automatically find include directories
+include_directories(
+  .
+  ${INCLUDE_PATH}/include
+  #./../mod/GSL/
+  ../api)
+
+add_executable(vmbuild ${SOURCES})
+target_link_libraries(vmbuild stdc++)
+add_executable(elf_syms ${ELF_SYMS_SOURCES})
+target_link_libraries(elf_syms stdc++)
+#
+# Installation
+#
+set(CMAKE_INSTALL_MESSAGE LAZY) # to avoid spam
+
+install(TARGETS vmbuild elf_syms DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/vmbuild/elf_syms.cpp
+++ b/vmbuild/elf_syms.cpp
@@ -1,0 +1,211 @@
+#include <algorithm>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <cassert>
+#include <vector>
+#include "../api/util/elf_binary.hpp"
+#include "../api/util/crc32.hpp"
+#include <unistd.h>
+
+static char* elf_header_location;
+static const char* elf_offset(int o) noexcept {
+  return elf_header_location + o;
+}
+
+static char* pruned_location = nullptr;
+static const char* syms_file = "_elf_symbols.bin";
+
+static int prune_elf_symbols(char*);
+
+int main(int argc, const char** args)
+{
+  assert(argc > 1);
+  FILE* f = fopen(args[1], "r");
+  assert(f);
+
+  // Determine file size
+  fseek(f, 0, SEEK_END);
+  int size = ftell(f);
+
+  char* fdata = new char[size];
+
+  rewind(f);
+  int res = fread(fdata, sizeof(char), size, f);
+  assert(res == size);
+  fclose(f);
+
+  auto carch = getenv("ARCH");
+  std::string arch = "x86_64";
+  if (carch) arch = std::string(carch);
+//  fprintf(stderr, "ARCH = %s\n", arch.c_str());
+
+  int pruned_size = 0;
+  fprintf(stderr, "%s: Pruning ELF symbols \n", args[0]);
+
+  pruned_size = prune_elf_symbols(fdata);
+  // validate size
+  assert(pruned_size != 0);
+
+  // write symbols to binary file
+  f = fopen(syms_file, "w");
+  assert(f);
+  fwrite(pruned_location, sizeof(char), pruned_size, f);
+  fclose(f);
+  return 0;
+}
+
+struct SymTab {
+  const char* base;
+  uint32_t    entries;
+};
+struct StrTab {
+  const char* base;
+  uint32_t    size;
+
+  StrTab(const char* base, uint32_t size) : base(base), size(size) {}
+};
+
+struct relocate_header
+{
+  uint32_t  symtab_entries;
+  uint32_t  strtab_size;
+  uint32_t  sanity_check;
+  uint32_t  checksum_syms;
+  uint32_t  checksum_strs;
+  char      data[0];
+};
+
+template <typename ElfSym, int Bits>
+static int relocate_pruned(char* new_location, SymTab& symtab, StrTab& strtab)
+{
+  auto& hdr = *(relocate_header*) new_location;
+
+  // first prune symbols
+  auto*  symloc = (ElfSym*) hdr.data;
+  size_t symidx = 0;
+  for (size_t i = 0; i < symtab.entries; i++)
+  {
+    auto& cursym = ((const ElfSym*) symtab.base)[i];
+    int   type;
+    if (Bits == 32)
+        type = ELF32_ST_TYPE(cursym.st_info);
+    else if (Bits == 64)
+        type = ELF64_ST_TYPE(cursym.st_info);
+    else
+        throw std::runtime_error("Invalid bits");
+    // we want both functions and untyped, because some
+    // C functions are NOTYPE
+    if (type == STT_FUNC || type == STT_NOTYPE) {
+      symloc[symidx++] = cursym;
+    }
+  }
+  // new total symbol entries
+  hdr.symtab_entries = symidx;
+
+  // move strings (one by one)
+  char*  strloc = (char*) &symloc[hdr.symtab_entries];
+  size_t index  = 0;
+  for (size_t i = 0; i < hdr.symtab_entries; i++)
+  {
+    auto& sym = symloc[i];
+    // get original location and length
+    const char* org = &strtab.base[sym.st_name];
+    size_t      len = strlen(org) + 1;
+    // set new symbol name location
+    sym.st_name = index; // = distance from start
+    // insert string into new location
+    memcpy(&strloc[index], org, len);
+    index += len;
+  }
+  // new entry base and total length
+  hdr.strtab_size = index;
+  // length of symbols & strings
+  const size_t size =
+         hdr.symtab_entries * sizeof(ElfSym) +
+         hdr.strtab_size * sizeof(char);
+
+  // checksum of symbols & strings and the entire section
+  hdr.checksum_syms = crc32_fast(symloc, hdr.symtab_entries * sizeof(ElfSym));
+  hdr.checksum_strs = crc32_fast(strloc, hdr.strtab_size);
+  uint32_t hdr_csum = crc32_fast(&hdr, sizeof(relocate_header) + size);
+  fprintf(stderr, "ELF symbols: %08x  "
+                  "ELF strings: %08x  "
+                  "ELF section: %08x\n",
+                  hdr.checksum_syms, hdr.checksum_strs, hdr_csum);
+  hdr.sanity_check = 0;
+  // header consistency check
+  hdr.sanity_check = crc32_fast(new_location, sizeof(relocate_header));
+
+  // return total length
+  return sizeof(relocate_header) + size;
+}
+
+template <int Bits, typename ElfEhdr, typename ElfShdr, typename ElfSym>
+static int prune_elf_symbols()
+{
+  SymTab symtab { nullptr, 0 };
+  std::vector<StrTab> strtabs;
+  auto& elf_hdr = *(ElfEhdr*) elf_header_location;
+  //printf("ELF header has %u sections\n", elf_hdr.e_shnum);
+
+  auto* shdr = (ElfShdr*) elf_offset(elf_hdr.e_shoff);
+
+  for (auto i = 0; i < elf_hdr.e_shnum; i++)
+  {
+    switch (shdr[i].sh_type) {
+    case SHT_SYMTAB:
+      symtab = SymTab { elf_offset(shdr[i].sh_offset),
+                        (uint32_t) shdr[i].sh_size / (uint32_t) sizeof(ElfSym) };
+      break;
+    case SHT_STRTAB:
+      strtabs.emplace_back(elf_offset(shdr[i].sh_offset), shdr[i].sh_size);
+      break;
+    case SHT_DYNSYM:
+    default:
+      break; // don't care tbh
+    }
+  }
+  //printf("symtab at %p (%u entries)\n", symtab.base, symtab.entries);
+
+  // not stripped
+  if (symtab.entries && !strtabs.empty()) {
+    StrTab strtab = *std::max_element(std::begin(strtabs), std::end(strtabs),
+                    [](auto const& lhs, auto const& rhs) { return lhs.size < rhs.size; });
+
+    // allocate worst case, guaranteeing we have enough space
+    pruned_location =
+        new char[sizeof(relocate_header) + symtab.entries * sizeof(ElfSym) + strtab.size];
+    return relocate_pruned<ElfSym, Bits>(pruned_location, symtab, strtab);
+  }
+  // stripped variant
+  pruned_location = new char[sizeof(relocate_header)];
+  memset(pruned_location, 0, sizeof(relocate_header));
+  return sizeof(relocate_header);
+}
+
+static int prune_elf32_symbols(char* location)
+{
+  elf_header_location = location;
+  return prune_elf_symbols<32, Elf32_Ehdr, Elf32_Shdr, Elf32_Sym> ();
+}
+static int prune_elf64_symbols(char* location)
+{
+  elf_header_location = location;
+  return prune_elf_symbols<64, Elf64_Ehdr, Elf64_Shdr, Elf64_Sym> ();
+}
+
+static int prune_elf_symbols(char* location)
+{
+  auto* hdr = (Elf32_Ehdr*) location;
+  assert(hdr->e_ident[EI_MAG0] == ELFMAG0);
+  assert(hdr->e_ident[EI_MAG1] == ELFMAG1);
+  assert(hdr->e_ident[EI_MAG2] == ELFMAG2);
+  assert(hdr->e_ident[EI_MAG3] == ELFMAG3);
+
+  if (hdr->e_ident[EI_CLASS] == ELFCLASS32)
+      return prune_elf32_symbols(location);
+  else if (hdr->e_ident[EI_CLASS] == ELFCLASS64)
+      return prune_elf64_symbols(location);
+  assert(0 && "Unknown ELF class");
+}

--- a/vmbuild/vmbuild.cpp
+++ b/vmbuild/vmbuild.cpp
@@ -1,0 +1,294 @@
+// This file is a part of the IncludeOS unikernel - www.includeos.org
+//
+// Copyright 2015 Oslo and Akershus University College of Applied Sciences
+// and Alfred Bratterud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include <fstream>
+#include <cstring>
+#include <iostream>
+
+#include <errno.h>
+#include <cstdio>
+#include <cstdlib>
+#include <sys/stat.h>
+#include <cassert>
+#include <elf.h>
+
+#include "../api/boot/multiboot.h"
+
+#define GSL_THROW_ON_CONTRACT_VIOLATION
+#include "../api/util/elf_binary.hpp"
+
+#define SECT_SIZE 512
+#define SECT_SIZE_ERR  666
+#define DISK_SIZE_ERR  999
+
+bool verb = false;
+
+#define INFO_(FROM, TEXT, ...) if (verb) fprintf(stderr, "%13s ] " TEXT "\n", "[ " FROM, ##__VA_ARGS__)
+#define INFO(X,...) INFO_("Vmbuild", X, ##__VA_ARGS__)
+#define WARN(X,...) fprintf(stderr, "[ vmbuild ] Warning: " X "\n", ##__VA_ARGS__)
+#define ERROR(X,...) fprintf(stderr, "[ vmbuild ] Error: " X "\n", ##__VA_ARGS__); std::terminate()
+
+
+// Special variables inside the bootloader
+struct bootvars {
+  const uint32_t __first_instruction;
+  uint32_t size;
+  uint32_t entry;
+  uint32_t load_addr;
+};
+
+static bool test {false};
+
+const std::string info  {"Create a bootable disk image for IncludeOS.\n"};
+const std::string usage {"Usage: vmbuild <service_binary> [<bootloader>][-test]\n"};
+
+std::string includeos_install = "/usr/local/includeos/";
+
+class Vmbuild_error : public std::runtime_error {
+  using runtime_error::runtime_error;
+};
+
+std::string get_bootloader_path(int argc, char** argv) {
+
+  if (argc == 2) {
+    // Determine IncludeOS install location from environment, or set to default
+    std::string arch = "x86_64";
+    auto env_arch = getenv("ARCH");
+
+    if (env_arch)
+      arch = std::string(env_arch);
+
+    std::string includeos_install = "/usr/local/includeos/" + arch;
+
+    if (auto env_prefix = getenv("INCLUDEOS_PREFIX"))
+      includeos_install = std::string{env_prefix} + "/includeos/" + arch;
+
+    return includeos_install + "/boot/bootloader";
+  } else {
+    return argv[2];
+  }
+}
+
+int main(int argc, char** argv)
+{
+  // Verify proper command usage
+  if (argc < 2) {
+    std::cout << info << usage;
+    exit(EXIT_FAILURE);
+  }
+
+  // Set verbose from environment
+  const char* env_verb = getenv("VERBOSE");
+  if (env_verb && strlen(env_verb) > 0)
+      verb = true;
+
+  const std::string bootloader_path = get_bootloader_path(argc, argv);
+
+  if (argc > 2)
+    const std::string bootloader_path {argv[2]};
+
+  INFO("Using bootloader %s" , bootloader_path.c_str());
+
+  const std::string elf_binary_path  {argv[1]};
+  const std::string img_name {elf_binary_path.substr(elf_binary_path.find_last_of("/") + 1, std::string::npos) + ".img"};
+
+  INFO("Creating image '%s'" , img_name.c_str());
+
+  if (argc > 3) {
+    if (std::string{argv[3]} == "-test") {
+      test = true;
+      verb = true;
+    } else if (std::string{argv[3]} == "-v"){
+      verb = true;
+    }
+  }
+
+  struct stat stat_boot;
+  struct stat stat_binary;
+
+  // Validate boot loader
+  if (stat(bootloader_path.c_str(), &stat_boot) == -1) {
+    INFO("Could not open %s, exiting\n" , bootloader_path.c_str());
+    return errno;
+  }
+
+  if (stat_boot.st_size != SECT_SIZE) {
+    INFO("Boot sector not exactly one sector in size (%ld bytes, expected %i)",
+         stat_boot.st_size, SECT_SIZE);
+    return SECT_SIZE_ERR;
+  }
+
+  INFO("Size of bootloader: %ld\t" , stat_boot.st_size);
+
+  // Validate service binary location
+  if (stat(elf_binary_path.c_str(), &stat_binary) == -1) {
+    ERROR("vmbuild: Could not open '%s'\n" , elf_binary_path.c_str());
+    return errno;
+  }
+
+  intmax_t binary_sectors = stat_binary.st_size / SECT_SIZE;
+  if (stat_binary.st_size & (SECT_SIZE-1)) binary_sectors += 1;
+
+  INFO("Size of service: \t%ld bytes" , stat_binary.st_size);
+
+  const decltype(binary_sectors) img_size_sect  {1 + binary_sectors};
+  const decltype(binary_sectors) img_size_bytes {img_size_sect * SECT_SIZE};
+  assert((img_size_bytes & (SECT_SIZE-1)) == 0);
+
+  INFO("Total disk size: \t%ld bytes, => %ld sectors",
+       img_size_bytes, img_size_sect);
+
+  const auto disk_size = img_size_bytes;
+
+  INFO("Creating disk of size %ld sectors / %ld bytes" ,
+       (disk_size / SECT_SIZE), disk_size);
+
+  std::vector<char> disk (disk_size);
+
+  auto* disk_head = disk.data();
+
+  std::ifstream file_boot {bootloader_path}; //< Load the boot loader into memory
+
+  auto read_bytes = file_boot.read(disk_head, stat_boot.st_size).gcount();
+  INFO("Read %ld bytes from boot image", read_bytes);
+
+  std::ifstream file_binary {elf_binary_path}; //< Load the service into memory
+
+  auto* binary_imgloc = disk_head + SECT_SIZE; //< Location of service code within the image
+
+  read_bytes = file_binary.read(binary_imgloc, stat_binary.st_size).gcount();
+  INFO("Read %ld bytes from service image" , read_bytes);
+
+  // only accept ELF binaries
+  if (not (binary_imgloc[EI_MAG0] == ELFMAG0
+           && binary_imgloc[EI_MAG1] == ELFMAG1
+           && binary_imgloc[EI_MAG2] == ELFMAG2
+           && binary_imgloc[EI_MAG3] == ELFMAG3))
+  {
+    ERROR("Not ELF binary");
+  }
+
+  // Required bootloader info
+  uint32_t srv_entry{};
+  uint32_t srv_load_addr{};
+  uint32_t binary_load_offs{};
+
+  multiboot_header* multiboot_hdr = nullptr;
+
+  // 32-bit ELF
+  if (binary_imgloc[EI_CLASS] == ELFCLASS32)
+   {
+    Elf_binary<Elf32> binary ({binary_imgloc, stat_binary.st_size});
+    binary.validate();
+    srv_entry = binary.entry();
+
+    INFO("Found 32-bit ELF with entry at 0x%x", srv_entry);
+
+    auto loadable = binary.loadable_segments();
+    if (loadable.size() > 1) {
+      WARN("found %zu loadable segments. Loading as one.",loadable.size());
+    }
+    srv_load_addr = loadable[0]->p_paddr;
+    binary_load_offs = loadable[0]->p_offset;
+
+    auto& sh_multiboot = binary.section_header(".multiboot");
+    multiboot_hdr = reinterpret_cast<multiboot_header*>(binary.section_data(sh_multiboot).data());
+
+  }
+
+  // 64-bit ELF
+  else if (binary_imgloc[EI_CLASS] == ELFCLASS64)
+  {
+    Elf_binary<Elf64> binary ({binary_imgloc, stat_binary.st_size});
+    binary.validate();
+    srv_entry = binary.entry();
+
+    INFO("Found 64-bit ELF with entry at 0x%x", srv_entry);
+
+    auto loadable = binary.loadable_segments();
+    // Expects(loadable.size() == 1);
+    // TODO: Handle multiple loadable segments properly
+    srv_load_addr = loadable[0]->p_paddr;
+    binary_load_offs = loadable[0]->p_offset;
+
+    auto& sh_multiboot = binary.section_header(".multiboot");
+    multiboot_hdr = reinterpret_cast<multiboot_header*>(binary.section_data(sh_multiboot).data());
+  }
+
+  // Unknown ELF format
+  else
+  {
+    ERROR("Unknown ELF format");
+  }
+
+
+  INFO("Verifying multiboot header:");
+  INFO("Magic value: 0x%x" , multiboot_hdr->magic);
+  if (multiboot_hdr->magic != MULTIBOOT_HEADER_MAGIC) {
+    ERROR("Multiboot magic mismatch: 0x%08x vs %#x",
+          multiboot_hdr->magic, MULTIBOOT_HEADER_MAGIC);
+  }
+
+
+  INFO("Flags: 0x%x" , multiboot_hdr->flags);
+  INFO("Checksum: 0x%x" , multiboot_hdr->checksum);
+  INFO("Checksum computed: 0x%x", multiboot_hdr->checksum + multiboot_hdr->flags + multiboot_hdr->magic);
+
+  // Verify multiboot header checksum
+  assert(multiboot_hdr->checksum + multiboot_hdr->flags + multiboot_hdr->magic == 0);
+
+  INFO("Header addr: 0x%x" , multiboot_hdr->header_addr);
+  INFO("Load start: 0x%x" , multiboot_hdr->load_addr);
+  INFO("Load end: 0x%x" , multiboot_hdr->load_end_addr);
+  INFO("BSS end: 0x%x" , multiboot_hdr->bss_end_addr);
+  INFO("Entry: 0x%x" , multiboot_hdr->entry_addr);
+
+  assert(multiboot_hdr->entry_addr == srv_entry);
+
+  // Load binary starting at first loadable segmento
+  uint32_t srv_size = binary_sectors;
+
+  srv_load_addr -= binary_load_offs;
+
+  // Write binary size and entry point to the bootloader
+  bootvars* boot = reinterpret_cast<bootvars*>(disk_head);
+
+  boot->size       = srv_size;
+  boot->entry      = srv_entry;
+  boot->load_addr  = srv_load_addr;
+
+  INFO("srv_size: %i", srv_size);
+  INFO("srv_entry: 0x%x", srv_entry);
+  INFO("srv_load: 0x%x", srv_load_addr);
+
+  if (test) {
+    INFO("\nTEST overwriting service with testdata");
+    for(int i {0}; i < (img_size_bytes - 512); ++i) {
+      disk[(512 + i)] = (i % 256);
+    }
+  } //< if (test)
+
+  // Write the image
+  auto* image = fopen(img_name.c_str(), "w");
+  auto  wrote = fwrite(disk_head, 1, disk_size, image);
+
+  INFO("Wrote %ld bytes => %ld sectors to '%s'",
+       wrote, (wrote / SECT_SIZE), img_name.c_str());
+
+  fclose(image);
+}


### PR DESCRIPTION
This reverts commit 07ad9e23fce5962b131baab839de955678c3c7c9.

Adds back vmbuild, for easier maintanence. It was moved to a separate repo, includeos/vmbuild, but we now want to have all dependencies in one place.

I hope this will retain file history - it's a simple `git revert 07ad9e2` 