### PR TITLE
It links! An example binary linking with IncludeOS (WIP)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,8 +10,10 @@
 { nixpkgs ? ./pinned.nix, # Builds cleanly May 9. 2024
   pkgs ? (import nixpkgs { }).pkgsStatic,
 
+  llvmPkgs ? pkgs.llvmPackages_16,
+
   # This env has musl and LLVM's libc++ as static libraries.
-  stdenv ? pkgs.llvmPackages_16.libcxxStdenv
+  stdenv ? llvmPkgs.libcxxStdenv
 }:
 
 assert (stdenv.buildPlatform.isLinux == false) ->
@@ -93,6 +95,7 @@ let
       #inherit s2n-tls;
       inherit musl-includeos;
       inherit cmake;
+      inherit microsoft_gsl;
     };
 
     meta = {
@@ -101,5 +104,72 @@ let
       license = pkgs.lib.licenses.asl20;
     };
   };
+
+  # A bootable example binary
+  example = stdenv.mkDerivation rec {
+
+    pname = "inludeos_example";
+    src = pkgs.lib.cleanSource ./example/.;
+
+    nativeBuildInputs = [
+      cmake
+      pkgs.nasm
+    ];
+
+    buildInputs = [
+      includeos.microsoft_gsl
+      includeos
+    ];
+
+    # TODO:
+    # We currently need to explicitly pass in because we link with a linker script
+    # and need to control linking order.
+    # This can be moved to os.cmake eventually, once we figure out how to expose
+    # them to cmake from nix without having to make cmake depend on nix.
+    # * Maybe we should make symlinks from the includeos package to them.
+
+    libcxx    = "${stdenv.cc.libcxx}/lib/libc++.a";
+    libcxxabi = "${stdenv.cc.libcxx}/lib/libc++abi.a";
+    libunwind = "${llvmPkgs.libraries.libunwind}/lib/libunwind.a";
+
+    linkdeps = [
+      libcxx
+      libcxxabi
+      libunwind
+    ];
+
+    cmakeFlags = [
+      "-DINCLUDEOS_PACKAGE=${includeos}"
+      "-DINCLUDEOS_LIBC_PATH=${musl-includeos}/lib/libc.a"
+      "-DINCLUDEOS_LIBCXX_PATH=${libcxx}"
+      "-DINCLUDEOS_LIBCXXABI_PATH=${libcxxabi}"
+      "-DINCLUDEOS_LIBUNWIND_PATH=${libunwind}"
+
+      "-DARCH=x86_64"
+      "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+    ];
+
+    preBuild = ''
+      echo ""
+      echo "📣 preBuild: about to build - can it work?  Yes! 🥁🥁🥁"
+      echo "Validating dependencies: "
+      for dep in ${toString linkdeps}; do
+          echo "Checking $dep:"
+          file $dep
+        done
+      echo ""
+    '';
+
+    postBuild = ''
+      echo "🎉 POST BUILD - you made it pretty far! 🗻⛅"
+      if [[ $? -ne 0 ]]; then
+        echo "Build failed. Running post-processing..."
+        echo "Performing cleanup or logging"
+      fi
+    '';
+
+    version = "dev";
+  };
 in
-  includeos
+#includeos
+example

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.0)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+
+project(hello_includeos)
+
+# IncludeOS binary install location
+# INCLUDEOS_SOURCE 👈 needed for rapid iteration on IncludeOS' cmake files
+
+message(status "Libunwind at: ${INCLUDEOS_LIBUNWIND_PATH}")
+
+set(LIBRARIES
+  ${INCLUDEOS_PACKAGE}/lib/libos.a
+  ${INCLUDEOS_PACKAGE}/platform/libx86_64_pc.a
+  ${INCLUDEOS_PACKAGE}/lib/libarch.a
+  ${INCLUDEOS_PACKAGE}/lib/libos.a
+  # libosdeps
+  ${INCLUDEOS_PACKAGE}/platform/libx86_64_pc.a
+  ${INCLUDEOS_PACKAGE}/lib/libarch.a
+  
+  ${INCLUDEOS_PACKAGE}/lib/libmusl_syscalls.a
+  ${INCLUDEOS_PACKAGE}/lib/libos.a
+  
+  ${INCLUDEOS_LIBCXX_PATH}
+  ${INCLUDEOS_LIBCXXABI_PATH}
+  ${INCLUDEOS_LIBUNWIND_PATH}
+  
+  ${INCLUDEOS_LIBC_PATH}
+  ${INCLUDEOS_PACKAGE}/lib/libmusl_syscalls.a
+  ${INCLDUEOS_LIBCXX_PATH}
+  ${INCLUDEOS_LIBCXXABI_PATH}
+  ${INCLUDEOS_PACKAGE}/lib/libos.a
+  ${INCLUDEOS_LIBUNWIND_PATH}
+  ${INCLUDEOS_LIBC_PATH}
+)
+
+include("${INCLUDEOS_PACKAGE}/cmake/os.cmake")
+
+os_add_executable(hello_includeos "Hello world - OS included" src/main.cpp)
+#os_add_drivers(hello virtionet vmxnet3 boot_logger)
+os_add_stdout(hello_includeos default_stdout)
+
+# This would be for application specific libs.
+#os_link_libraries(hello_includeos PRIVATE your_custom_lib)
+
+
+# TODO: remove or hide the ELF_POSTFIX.
+# currently os.cmake expects the target name to be TARGET.elf.bin
+# where TARGET is the first param to os_add_executable.
+# I added it here becuase nix expects an install target.
+set(BINARY_NAME hello_includeos)
+set(ELF_TARGET ${BINARY_NAME}${ELF_POSTFIX})
+
+install(TARGETS ${ELF_TARGET} DESTINATION bin)
+

--- a/example/src/main.cpp
+++ b/example/src/main.cpp
@@ -1,0 +1,7 @@
+#include <os>
+#include <service>
+
+void Service::start(const std::string& args){
+  printf("Args = %s\n", args.c_str());
+  printf("Try giving the service less memory, eg. 5MB in vm.json\n");
+}


### PR DESCRIPTION
It links, but we don't know if it boots yet. And it's not entirely clear if it will work since `musl-includeos` is used for linking, but musl from pkgsStatic is used for compiling. But it does contain the IncludeOS symbols such as `rock_bottom` and `_start` at the right order, and is definitely using our linker script. So it's progress. 

Note that we may want to revisit how this is done based on the discussion #2236. 