### PR TITLE
Separate nix-file for example and vmbuild, fix conflicts

### DIFF
--- a/example.nix
+++ b/example.nix
@@ -1,0 +1,71 @@
+{ nixpkgs ? ./pinned.nix,
+  includeos ? import ./default.nix { },
+  pkgs ? (import nixpkgs { }).pkgsStatic,
+  llvmPkgs ? pkgs.llvmPackages_16
+}:
+
+includeos.stdenv.mkDerivation rec {
+  pname = "includeos_example";
+  src = pkgs.lib.cleanSource ./example;
+  doCheck = false;
+  dontStrip = true;
+
+  nativeBuildInputs = [
+    pkgs.buildPackages.nasm
+    pkgs.buildPackages.cmake
+  ];
+
+  buildInputs = [
+    pkgs.microsoft_gsl
+    includeos
+  ];
+
+  # TODO:
+  # We currently need to explicitly pass in because we link with a linker script
+  # and need to control linking order.
+  # This can be moved to os.cmake eventually, once we figure out how to expose
+  # them to cmake from nix without having to make cmake depend on nix.
+  # * Maybe we should make symlinks from the includeos package to them.
+
+  libcxx    = "${includeos.stdenv.cc.libcxx}/lib/libc++.a";
+  libcxxabi = "${includeos.stdenv.cc.libcxx}/lib/libc++abi.a";
+  libunwind = "${llvmPkgs.libraries.libunwind}/lib/libunwind.a";
+
+  linkdeps = [
+    libcxx
+    libcxxabi
+    libunwind
+  ];
+
+  cmakeFlags = [
+    "-DINCLUDEOS_PACKAGE=${includeos}"
+    "-DINCLUDEOS_LIBC_PATH=${includeos.musl-includeos}/lib/libc.a"
+    "-DINCLUDEOS_LIBCXX_PATH=${libcxx}"
+    "-DINCLUDEOS_LIBCXXABI_PATH=${libcxxabi}"
+    "-DINCLUDEOS_LIBUNWIND_PATH=${libunwind}"
+
+    "-DARCH=x86_64"
+    "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+  ];
+
+  preBuild = ''
+    echo ""
+    echo "📣 preBuild: about to build - can it work?  Yes! 🥁🥁🥁"
+    echo "Validating dependencies: "
+    for dep in ${toString linkdeps}; do
+        echo "Checking $dep:"
+        file $dep
+      done
+    echo ""
+  '';
+
+  postBuild = ''
+    echo "🎉 POST BUILD - you made it pretty far! 🗻⛅"
+    if [[ $? -ne 0 ]]; then
+      echo "Build failed. Running post-processing..."
+      echo "Performing cleanup or logging"
+    fi
+  '';
+
+  version = "dev";
+}

--- a/vmbuild.nix
+++ b/vmbuild.nix
@@ -1,0 +1,26 @@
+{ nixpkgs ? ./pinned.nix,
+  pkgs ? import nixpkgs { config = { }; overlays = [ ]; },
+}:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "vmbuild";
+  version = "dev";
+
+  sourceRoot = pname;
+
+  srcs = [
+    ./vmbuild
+    ./src
+    ./api
+    ];
+
+  nativeBuildInputs = [
+    pkgs.cmake
+    pkgs.nasm
+  ];
+
+  buildInputs = [
+    pkgs.microsoft_gsl
+  ];
+
+}

--- a/vmbuild/CMakeLists.txt
+++ b/vmbuild/CMakeLists.txt
@@ -12,32 +12,11 @@ endif()
 set(SOURCES vmbuild.cpp)
 set(ELF_SYMS_SOURCES elf_syms.cpp ../src/util/crc32.cpp)
 
-
-
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wextra -O2 -g")
 
 
-if(CONAN_EXPORTED) # in conan local cache
-  # standard conan installation, deps will be defined in conanfile.py
-  # and not necessary to call conan again, conan is already running
-  include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
-  conan_basic_setup()
-else()
-  if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-     message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-     file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/master/conan.cmake"
-                    "${CMAKE_BINARY_DIR}/conan.cmake")
-  endif()
-  ##needed by conaningans
-
-  include(${CMAKE_BINARY_DIR}/conan.cmake)
-  conan_cmake_run(
-    REQUIRES GSL/2.0.0@includeos/test
-    BASIC_SETUP
-  )
-endif(CONAN_EXPORTED)
 #TODO pull vmbuild conanfile.py inn when not building with conan to get deps
 # TODO: write scripts that automatically find include directories
 include_directories(


### PR DESCRIPTION
This adds vmbuild.nix to build the vmbuild-tools and moves the example from default.nix to example.nix.

They can be built separately with:

nix-build ./vmbuild.nix
nix-build ./example.nix

This should also remove the conflicts from #2236 