### PR TITLE
Only include required files in IncludeOS nix package

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -28,9 +28,6 @@ final: prev: {
             ./deps
             ./userspace
             ./lib
-            ./default.nix
-            ./overlay.nix
-            ./pinned.nix
             ./CMakeLists.txt
           ];
       };

--- a/overlay.nix
+++ b/overlay.nix
@@ -13,11 +13,27 @@ final: prev: {
 
     # IncludeOS
     includeos = self.stdenv.mkDerivation rec {
+      enableParallelBuilding = true;
       pname = "includeos";
 
       version = "dev";
 
-      src = prev.pkgsStatic.lib.cleanSource ./.;
+      src = prev.pkgsStatic.lib.fileset.toSource {
+          root = ./.;
+          # Only include files needed by IncludeOS (not examples, docs etc)
+          fileset = prev.pkgsStatic.lib.fileset.unions [
+            ./src
+            ./api
+            ./cmake
+            ./deps
+            ./userspace
+            ./lib
+            ./default.nix
+            ./overlay.nix
+            ./pinned.nix
+            ./CMakeLists.txt
+          ];
+      };
 
       # If you need to patch, this is the place
       postPatch = '''';


### PR DESCRIPTION
This avoids rebuilding the OS when working on in-tree packages that depend on `./default.nix`, such as `./example.nix`.

Also enables parallel building, but I'm not sure this affects build time at all.