### PR TITLE
Package unikernel dependencies with IncludeOS

### DIFF
--- a/chainloader.nix
+++ b/chainloader.nix
@@ -31,11 +31,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DINCLUDEOS_PACKAGE=${includeos}"
-    "-DINCLUDEOS_LIBC_PATH=${includeos.libraries.libc}"
-    "-DINCLUDEOS_LIBCXX_PATH=${includeos.libraries.libcxx}"
-    "-DINCLUDEOS_LIBCXXABI_PATH=${includeos.libraries.libcxxabi}"
-    "-DINCLUDEOS_LIBUNWIND_PATH=${includeos.libraries.libunwind}"
-    "-DINCLUDEOS_LIBGCC_PATH=${includeos.libraries.libgcc}"
   ];
 
   srcs = [

--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -46,14 +46,12 @@ if (DISKBUILDER-NOTFOUND)
 endif()
 
 set(LINK_SCRIPT ${INCLUDEOS_PACKAGE}/linker.ld)
-#includeos package can provide this!
+
 include_directories(
   ${INCLUDEOS_PACKAGE}/include/os
 )
 
-
-# arch and platform defines
-#TODO get from toolchain ?
+# Arch and platform defines
 set(CMAKE_CXX_COMPILER_TARGET ${TRIPLE})
 set(CMAKE_C_COMPILER_TARGET ${TRIPLE})
 
@@ -158,8 +156,31 @@ function(os_add_executable TARGET NAME)
 
   set_target_properties(${ELF_TARGET} PROPERTIES LINK_FLAGS ${LDFLAGS})
 
-  # TODO: Find out which libraries we need
-  #conan_find_libraries_abs_path("${CONAN_LIBS}" "${CONAN_LIB_DIRS}" LIBRARIES)
+  if (${PLATFORM} STREQUAL "x86_pc")
+    set(LIBPLATFORM lib${ARCH}_pc.a)
+  elseif (${PLATFORM} STREQUAL "nano")
+    set(LIBPLATFORM lib${ARCH}_nano.a)
+  else()
+    set(LIBPLATFORM lib${ARCH}_${PLATFORM}.a)
+  endif()
+
+  if (${ARCH} STREQUAL "i686")
+    set(LIBGCC libclang_rt.builtins-i386.a)
+  else()
+    set(LIBGCC libclang_rt.builtins-${ARCH}.a)
+  endif()
+
+  set(LIBRARIES
+    ${INCLUDEOS_PACKAGE}/lib/libos.a
+    ${INCLUDEOS_PACKAGE}/platform/${LIBPLATFORM}
+    ${INCLUDEOS_PACKAGE}/lib/libarch.a
+    ${INCLUDEOS_PACKAGE}/lib/libos.a
+    ${INCLUDEOS_PACKAGE}/libcxx/lib/libc++.a
+    ${INCLUDEOS_PACKAGE}/libc/lib/libc.a
+    ${INCLUDEOS_PACKAGE}/lib/libmusl_syscalls.a
+    ${INCLUDEOS_PACKAGE}/libunwind/lib/libunwind.a
+    ${INCLUDEOS_PACKAGE}/libgcc/lib/linux/${LIBGCC}
+  )
 
   message(STATUS ">>>>> 👉 Libraries: ${LIBRARIES}")
   foreach(_LIB ${LIBRARIES})

--- a/example.nix
+++ b/example.nix
@@ -29,12 +29,6 @@ includeos.stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DINCLUDEOS_PACKAGE=${includeos}"
-    "-DINCLUDEOS_LIBC_PATH=${includeos.libraries.libc}"
-    "-DINCLUDEOS_LIBCXX_PATH=${includeos.libraries.libcxx}"
-    "-DINCLUDEOS_LIBCXXABI_PATH=${includeos.libraries.libcxxabi}"
-    "-DINCLUDEOS_LIBUNWIND_PATH=${includeos.libraries.libunwind}"
-    "-DINCLUDEOS_LIBGCC_PATH=${includeos.libraries.libgcc}"
-
     "-DARCH=x86_64"
     "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
   ];

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -10,31 +10,6 @@ project(hello_includeos)
 
 message(status "Libunwind at: ${INCLUDEOS_LIBUNWIND_PATH}")
 
-set(LIBRARIES
-  ${INCLUDEOS_PACKAGE}/lib/libos.a
-  ${INCLUDEOS_PACKAGE}/platform/libx86_64_pc.a
-  ${INCLUDEOS_PACKAGE}/lib/libarch.a
-  ${INCLUDEOS_PACKAGE}/lib/libos.a
-  # libosdeps
-  ${INCLUDEOS_PACKAGE}/platform/libx86_64_pc.a
-  ${INCLUDEOS_PACKAGE}/lib/libarch.a
-
-  ${INCLUDEOS_PACKAGE}/lib/libmusl_syscalls.a
-  ${INCLUDEOS_PACKAGE}/lib/libos.a
-
-  ${INCLUDEOS_LIBCXX_PATH}
-  ${INCLUDEOS_LIBCXXABI_PATH}
-  ${INCLUDEOS_LIBUNWIND_PATH}
-
-  ${INCLUDEOS_LIBC_PATH}
-  ${INCLUDEOS_PACKAGE}/lib/libmusl_syscalls.a
-  ${INCLDUEOS_LIBCXX_PATH}
-  ${INCLUDEOS_LIBCXXABI_PATH}
-  ${INCLUDEOS_PACKAGE}/lib/libos.a
-  ${INCLUDEOS_LIBUNWIND_PATH}
-  ${INCLUDEOS_LIBC_PATH}
-)
-
 include("${INCLUDEOS_PACKAGE}/cmake/os.cmake")
 
 os_add_executable(hello_includeos "Hello world - OS included" src/main.cpp)

--- a/overlay.nix
+++ b/overlay.nix
@@ -40,14 +40,14 @@ final: prev: {
     includeos_stdenv = self.musl_includeos_stdenv_libcxx;
 
     libraries = {
-      libc = "${self.musl-includeos}/lib/libc.a";
-      libcxx = "${self.libcxx_musl_unpatched}/lib/libc++.a";
-      libcxxabi = "${self.libcxx_musl_unpatched}/lib/libc++abi.a";
-      libunwind = "${self.llvmPkgs.libraries.libunwind}/lib/libunwind.a";
-      libgcc = if self.stdenv.system == "i686-linux" then
-        "${self.llvmPkgs.compiler-rt}/lib/linux/libclang_rt.builtins-i386.a"
-      else
-        "${self.llvmPkgs.compiler-rt}/lib/linux/libclang_rt.builtins-x86_64.a";
+      libc = self.musl-includeos;
+      libcxx = {
+        # There doesn't seem to be a single package containing both libc++ headers and libs.
+        lib = "${self.libcxx_musl_unpatched}/lib";
+        include = "${self.libcxx_musl_unpatched.dev}/include/c++/v1";
+      };
+      libunwind = self.llvmPkgs.libraries.libunwind;
+      libgcc = self.llvmPkgs.compiler-rt;
     };
   });
 
@@ -110,6 +110,12 @@ final: prev: {
         echo Copying vmbuild binaries to tools/vmbuild
         mkdir -p "$out/tools/vmbuild"
         cp -v ${self.vmbuild}/bin/* "$out/tools/vmbuild"
+        cp -r -v ${final.stdenvIncludeOS.libraries.libc} $out/libc
+        mkdir $out/libcxx
+        cp -r -v ${final.stdenvIncludeOS.libraries.libcxx.lib} $out/libcxx/lib
+        cp -r -v ${final.stdenvIncludeOS.libraries.libcxx.include} $out/libcxx/include
+        cp -r -v ${final.stdenvIncludeOS.libraries.libunwind} $out/libunwind
+        cp -r -v ${final.stdenvIncludeOS.libraries.libgcc} $out/libgcc
         '';
 
       archFlags = if self.stdenv.targetPlatform.system == "i686-linux" then

--- a/src/chainload/CMakeLists.txt
+++ b/src/chainload/CMakeLists.txt
@@ -13,17 +13,6 @@ option(default_stdout "" ON)
 set(SOURCES
     service.cpp hotswap.cpp
   )
-set(LIBRARIES
-  ${INCLUDEOS_PACKAGE}/lib/libos.a
-  ${INCLUDEOS_PACKAGE}/lib/libarch.a
-  ${INCLUDEOS_PACKAGE}/lib/libmusl_syscalls.a
-  ${INCLUDEOS_PACKAGE}/platform/libi686_nano.a
-  ${INCLUDEOS_LIBCXX_PATH}
-  ${INCLUDEOS_LIBC_PATH}
-  ${INCLUDEOS_LIBUNWIND_PATH}
-  ${INCLUDEOS_LIBCXXABI_PATH}
-  ${INCLUDEOS_LIBGCC_PATH}
-)
 set(BINARY_NAME chainloader)
 
 os_add_executable(chainloader "IncludeOS chainloader" ${SOURCES})


### PR DESCRIPTION
- overlay.nix now copies libc, libcxx and friends to the IncludeOS package
- os.cmake is made responsible for finding libs inside the package
- delete library env vars from chainloader and example, no longer needed

Tested with `nix-build chainloader.nix && nix-build example.nix && boot result/bin/hello_includeos.elf.bin`