### PR TITLE
Add chainloader to nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
 { nixpkgs ? ./pinned.nix,
   overlays ? [ (import ./overlay.nix) ],
+  chainloader ? (import ./chainloader.nix {}),
   pkgs ? import nixpkgs {
     config = {};
     inherit overlays;
@@ -19,11 +20,11 @@ pkgs.mkShell rec {
     stdenv.cc
     pkgs.buildPackages.cmake
     pkgs.buildPackages.nasm
+    pkgs.pkgsIncludeOS.microsoft_gsl
   ];
 
-
   buildInputs = [
-    pkgs.pkgsIncludeOS.microsoft_gsl
+    chainloader
   ];
 
   bootloader="${includeos}/boot/bootloader";
@@ -31,6 +32,10 @@ pkgs.mkShell rec {
   shellHook = ''
     CC=${stdenv.cc}/bin/clang
     CXX=${stdenv.cc}/bin/clang++
+
+    # The 'boot' utility in the vmrunner package requires this env var
+    export INCLUDEOS_CHAINLOADER=${chainloader}/bin
+
     unikernel=$(realpath ${unikernel})
     echo -e "Attempting to build unikernel: \n$unikernel"
     if [ ! -d "$unikernel" ]; then

--- a/test/net/integration/udp/CMakeLists.txt
+++ b/test/net/integration/udp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-#service
+
 project (service)
 include(os)
 


### PR DESCRIPTION
This makes the chainloader available inside the nix shell, and exports the env var required by `boot`. 
I first tried adding it to `packages`, but then it seems to pull in some 32-bit stuff. This might not be the perfect way to set it up either, but it works.