### PR TITLE
Fix memmap_test

### DIFF
--- a/test/kernel/unit/memmap_test.cpp
+++ b/test/kernel/unit/memmap_test.cpp
@@ -42,9 +42,9 @@ CASE ("Using the fixed memory range class")
         for (; i != range.end(); i++)
           EXPECT(*i);
 
-        EXPECT_THROWS(++i);
-        EXPECT_THROWS(i++);
-
+        // Disabled, as range checks are not available in std::span
+        //EXPECT_THROWS(++i);
+        //EXPECT_THROWS(i++);
       }
 
       AND_THEN("You can check if any address is within that range") {


### PR DESCRIPTION
std::span does't have range checking, so the test fails. This commit just disables that part of the test.

The error was introduced when we switched from GSL::span, which had range checks.