### PR TITLE
Minor test improvements

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -40,7 +40,9 @@ pkgs.mkShell rec {
     CC=${stdenv.cc}/bin/clang
     CXX=${stdenv.cc}/bin/clang++
 
-    # The 'boot' utility in the vmrunner package requires this env var
+
+    # The 'boot' utility in the vmrunner package requires these env vars
+    export INCLUDEOS_VMRUNNER=${vmrunner}
     export INCLUDEOS_CHAINLOADER=${chainloader}/bin
 
     unikernel=$(realpath ${unikernel})

--- a/test.sh
+++ b/test.sh
@@ -10,6 +10,7 @@
 
 steps=0
 fails=0
+failed_tests=()
 
 success(){
   echo ""
@@ -26,7 +27,8 @@ success(){
 
 fail(){
   echo ""
-  echo "👷⛔ Step $1 failed"
+  echo "👷⛔ Step $1 failed ($2)"
+  failed_tests+=("step $1: $2")
 }
 
 run(){
@@ -49,7 +51,7 @@ run(){
     success $steps
   else
     echo "‼️  Error: Command failed with exit status $?"
-    fail $steps
+    fail $steps "$1"
     fails=$((fails + 1))
     return $?
   fi
@@ -154,7 +156,7 @@ run_testsuite() {
     if [ $? -eq 0 ]; then
       success "$steps.$substeps"
     else
-      fail "$steps.$substeps"
+      fail "$steps.$substeps" "$cmd"
       subfails=$((subfails + 1))
     fi
 
@@ -211,5 +213,10 @@ else
   echo ""
   echo "👷🧰 $fails / $steps steps failed. There's some work left to do. 🛠  "
   echo ""
+  echo "Failed tests:"
+  for t in "${failed_tests[@]}"; do
+    echo "$t"
+  done
+
   exit 1
 fi


### PR DESCRIPTION
- Add INCLUDE_VMRUNNER export in shell.nix 

Without this change I'm unable to run the tests that require vmrunner.

- Modify test.sh to output a list of failed tests before exiting

Example output:

```
👷🧰 3 / 6 steps failed. There's some work left to do. 🛠

Failed tests:
step 4: smoke_tests
step 5.9: nix-shell --argstr unikernel ./test/kernel/integration/smp/ --run ./test.py
step 5:
step 6.1: nix-shell --argstr unikernel ./test/net/integration/bufstore/ --run ./test.py
step 6.3: nix-shell --argstr unikernel ./test/net/integration/dns/ --run ./test.py
step 6.7: nix-shell --argstr unikernel ./test/net/integration/tcp/ --run ./test.py
step 6:
```

In the script, `fail()` is also called at the end of one section if one of the substep failed. This is why both "step 5.9: ..." and "step 5: " is shown. 