### PR TITLE
Add back ELF symbols in stacktraces, add more tests

### DIFF
--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -208,8 +208,10 @@ function(os_add_executable TARGET NAME)
         ${TARGET} ALL
         COMMENT "elf.syms"
         COMMAND ${ELF_SYMS} $<TARGET_FILE:${ELF_TARGET}>
+        # Copy symbols to .elf_symbols section
         COMMAND ${CMAKE_OBJCOPY} --update-section .elf_symbols=_elf_symbols.bin  $<TARGET_FILE:${ELF_TARGET}> ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}
-        #COMMAND ${STRIP_CMD} ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}
+        # Strip regular symbols
+        COMMAND ${CMAKE_STRIP} --strip-all ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}
         COMMAND mv $<TARGET_FILE:${ELF_TARGET}> $<TARGET_FILE:${ELF_TARGET}>.copy
         DEPENDS ${ELF_TARGET}
       )

--- a/test/kernel/integration/exception/CMakeLists.txt
+++ b/test/kernel/integration/exception/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
+set(ELF_SYMBOLS true)
+
 project (service)
 include(os)
 

--- a/test/kernel/integration/exception/test.py
+++ b/test/kernel/integration/exception/test.py
@@ -8,7 +8,7 @@ from vmrunner import vmrunner
 vm = vmrunner.vms[0]
 
 counter = 0
-expected = 3 # TODO: Change to 5 when we have builds with backtrace.
+expected = 5
 def is_good(line):
     global counter
     counter += 1
@@ -20,8 +20,7 @@ def is_good(line):
 vm.on_output("\\x15\\x07\\t\*\*\*\* PANIC \*\*\*\*", is_good)
 vm.on_output("Divide-by-zero Error", is_good)
 
-# TODO: Re-enable these when we have test builds with backtrace
-# vm.on_output("__cpu_exception", is_good)
-# vm.on_output("Service::start()", is_good)
+vm.on_output("__cpu_exception", is_good)
+vm.on_output("Service::start()", is_good)
 
-vm.boot(20,image_name='kernel_exception.elf.bin')
+vm.boot(20,image_name='kernel_exception')

--- a/test/kernel/integration/stacktrace/CMakeLists.txt
+++ b/test/kernel/integration/stacktrace/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.5)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(ELF_SYMBOLS true)
+
+project (service)
+include(os)
+
+set(SOURCES
+    service.cpp
+)
+
+os_add_executable(kernel_stacktrace "Stacktrace test" ${SOURCES})
+os_add_stdout(kernel_stacktrace default_stdout)
+os_add_drivers(kernel_stacktrace boot_logger)
+
+configure_file(test.py ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/kernel/integration/stacktrace/service.cpp
+++ b/test/kernel/integration/stacktrace/service.cpp
@@ -1,0 +1,8 @@
+#include <os>
+
+void Service::start()
+{
+  printf("Calling os::print_backtrace()\n");
+  os::print_backtrace();
+  printf("We reached the end.\n");
+}

--- a/test/kernel/integration/stacktrace/test.py
+++ b/test/kernel/integration/stacktrace/test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+from builtins import str
+import sys
+import os
+
+from vmrunner import vmrunner
+
+vm = vmrunner.vms[0]
+
+counter = 0
+expected = 4
+def is_good(line):
+    global counter, expected
+    counter += 1
+    print("<test.py> Found expected line {}/{}\n".format(counter, expected, line))
+    if (counter == expected):
+        vm.exit(0, "All tests passed")
+
+vm.on_output("Service::start()", is_good)
+vm.on_output("kernel_main", is_good)
+vm.on_output("__libc_start_main", is_good)
+vm.on_output("long_mode", is_good)
+
+vm.boot(20,image_name='kernel_stacktrace')

--- a/test/kernel/integration/stacktrace/vm.json
+++ b/test/kernel/integration/stacktrace/vm.json
@@ -1,0 +1,4 @@
+{
+  "image" : "service.img",
+  "smp" : 16
+}

--- a/vmbuild/elf_syms.cpp
+++ b/vmbuild/elf_syms.cpp
@@ -52,7 +52,8 @@ int main(int argc, const char** args)
   // write symbols to binary file
   f = fopen(syms_file, "w");
   assert(f);
-  fwrite(pruned_location, sizeof(char), pruned_size, f);
+  res = fwrite(pruned_location, sizeof(char), pruned_size, f);
+  assert(res == pruned_size);
   fclose(f);
   return 0;
 }


### PR DESCRIPTION
This PR adds back stacktraces with symbol information + adds tests. See commits for additional details.

The main change is adding  `__attribute__(section(".data"))` to the static struct `relocs` used to store ELF metadata to make sure it's included in the ELF .data section (not BSS). This is needed to make sure that we don't overwrite parts of it when we initialise BSS.

On boot we first load the symbol table from `.elf_symbols` and move it to a new memory location. The new location of the symbol table is stored in `relocs.syms`: https://github.com/includeos/IncludeOS/blob/v0.16.0-release/src/kernel/elf.cpp#L350

We then initialise/clear the BSS area: https://github.com/includeos/IncludeOS/blob/v0.16.0-release/src/platform/x86_pc/kernel_start.cpp#L95

This previously had the side effect of setting `relocs.syms` back to 0 and we lost the new location of the ELF symbol table. The ELF parser initialised a few lines below would then fail. 