### PR TITLE
Run tests with `nix-shell --pure`, add / fix dependencies.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -76,16 +76,20 @@ pkgs.mkShell rec {
     echo $(which $CXX)
     echo -e "\nIncludeOS package:"
     echo ${includeos}
-    echo -e "\n----------------------  Qemu bridge setup  ---------------------"
+    echo -e "\n---------------------- Network privileges  ---------------------"
     echo "The vmrunner for IncludeOS tests requires bridged networking for full functionality."
-    echo "In order to use bridge networking, you need the following:"
-    echo "1. the qemu-bridge-helper needs sudo. Can be enabled with:"
+    echo "The following commands requiring sudo privileges can be used to set this up:"
+    echo "1. the qemu-bridge-helper needs sudo to create a bridge. Can be enabled with:"
     echo "   sudo chmod u+s ${pkgs.qemu}/libexec/qemu-bridge-helper"
-    echo "2. bridge43 must exist. Can be set up with \$create_bridge :"
+    echo "2. bridge43 must exist. Can be set up with vmrunner's create_bridge.sh script:"
     echo "   ${vmrunner.create_bridge}"
     echo "3. /etc/qemu/bridge.conf must contain this line:"
     echo "   allow bridge43"
-    echo "These steps require sudo. Without them we're restricted to usermode networking."
+    echo ""
+    echo "Some tests require ping, which requires premissions to send raw packets. On some hosts"
+    echo "this is not enabled by default for iputils provided by nix. It can be enabled with:"
+    echo "4. sudo setcap cap_net_raw+ep ${pkgs.iputils}/bin/ping"
+    echo " "
     echo
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,10 @@ pkgs.mkShell rec {
     stdenv.cc
     pkgs.buildPackages.cmake
     pkgs.buildPackages.nasm
+    pkgs.qemu
+    pkgs.which
+    pkgs.grub2
+    pkgs.iputils
   ];
 
   buildInputs = [
@@ -39,7 +43,6 @@ pkgs.mkShell rec {
   shellHook = ''
     CC=${stdenv.cc}/bin/clang
     CXX=${stdenv.cc}/bin/clang++
-
 
     # The 'boot' utility in the vmrunner package requires these env vars
     export INCLUDEOS_VMRUNNER=${vmrunner}
@@ -73,5 +76,16 @@ pkgs.mkShell rec {
     echo $(which $CXX)
     echo -e "\nIncludeOS package:"
     echo ${includeos}
+    echo -e "\n----------------------  Qemu bridge setup  ---------------------"
+    echo "The vmrunner for IncludeOS tests requires bridged networking for full functionality."
+    echo "In order to use bridge networking, you need the following:"
+    echo "1. the qemu-bridge-helper needs sudo. Can be enabled with:"
+    echo "   sudo chmod u+s ${pkgs.qemu}/libexec/qemu-bridge-helper"
+    echo "2. bridge43 must exist. Can be set up with \$create_bridge :"
+    echo "   ${vmrunner.create_bridge}"
+    echo "3. /etc/qemu/bridge.conf must contain this line:"
+    echo "   allow bridge43"
+    echo "These steps require sudo. Without them we're restricted to usermode networking."
+    echo
   '';
 }

--- a/test.sh
+++ b/test.sh
@@ -70,10 +70,10 @@ build_example(){
 }
 
 smoke_tests(){
-  nix-shell --argstr unikernel ./test/net/integration/udp --run ./test.py
-  nix-shell --argstr unikernel ./test/net/integration/tcp --run ./test.py
-  nix-shell --argstr unikernel ./test/kernel/integration/paging --run ./test.py
-  nix-shell --argstr unikernel ./test/kernel/integration/smp --run ./test.py
+  nix-shell --pure  --argstr unikernel ./test/net/integration/udp --run ./test.py
+  nix-shell --pure --argstr unikernel ./test/net/integration/tcp --run ./test.py
+  nix-shell --pure --argstr unikernel ./test/kernel/integration/paging --run ./test.py
+  nix-shell --pure --argstr unikernel ./test/kernel/integration/smp --run ./test.py
 }
 
 run unittests "Build and run unit tests"
@@ -139,7 +139,7 @@ run_testsuite() {
 
 
     # The command to run, as string to be able to print the fully expanded command
-    cmd="nix-shell --argstr unikernel $subfolder --run ./test.py"
+    cmd="nix-shell --pure --argstr unikernel $subfolder --run ./test.py"
 
     echo ""
     echo "🚧 Step $steps.$substeps"

--- a/test/net/integration/slaac/test.py
+++ b/test/net/integration/slaac/test.py
@@ -26,7 +26,7 @@ def Slaac_test(trigger_line):
   print(color.INFO("<Test.py>"), "Trying to ping")
   time.sleep(1)
   try:
-    command = ["ping6", "-I", "bridge43", ip_string.rstrip(), "-c",
+    command = ["ping", "-I", "bridge43", ip_string.rstrip(), "-c",
             str(ping_count) ]
     print(color.DATA(" ".join(command)))
     print(subprocess.check_output(command))


### PR DESCRIPTION
Running test.sh on a new machine revealed some missing dependencies. Running
tests with `--pure` will ensure that only the nix provided packages can be used
during tests, improving reproducability. 

The qemu bridge setup instructions were also added to shell.nix for convenience.
`IncludeOS$ nix-shell`
should now make it clear how to configure the network bridge required for
integration tests to pass.