### PR TITLE
Add STL tests

### DIFF
--- a/deps/lest/default.nix
+++ b/deps/lest/default.nix
@@ -1,0 +1,27 @@
+{
+  pkgs,
+  stdenv
+}:
+stdenv.mkDerivation rec {
+  pname = "lest";
+  version = "1.35.2";
+
+  meta = {
+    description = "A tiny C++11 test framework – lest errors escape testing.";
+    homepage = "https://github.com/martinmoene/lest";
+    license = pkgs.lib.licenses.boost;
+  };
+
+  src = fetchGit {
+    url = "https://github.com/martinmoene/lest.git";
+    rev = "1eda2f7c33941617fc368ce764b5fbeffccb59bc";
+  };
+
+  cmakeBuildType = "Debug";
+
+  postBuild = ''
+      mkdir -p "$out/include"
+      cp -r include "$out/"
+    '';
+
+}

--- a/test.sh
+++ b/test.sh
@@ -82,10 +82,10 @@ run build_chainloader "Build the 32-bit chainloader"
 
 run build_example "Build the basic example"
 
-run smoke_tests "Build and run a few key smoke tests"
+if [ "$QUICK_SMOKE" ]; then
 
+  run smoke_tests "Build and run a few key smoke tests"
 
-if [ -n "$QUICK_SMOKE" ]; then
   if [ $fails -eq 0 ]; then
     echo ""
     echo "👷💬 A lot of things are working! 💪"
@@ -183,6 +183,16 @@ exclusions=(
 )
 
 run_testsuite "./test/kernel/integration" "${exclusions[@]}"
+
+#
+# C++ STL runtime tests
+#
+exclusions=(
+
+)
+
+run_testsuite "./test/stl/integration" "${exclusions[@]}"
+
 
 #
 # Networking tests

--- a/test/stl/integration/coroutines/README.md
+++ b/test/stl/integration/coroutines/README.md
@@ -1,3 +1,3 @@
-# Test Coroutines TS
+# Test Coroutines
 
-Test the C++ Couroutines TS compatibility with IncludeOS and SMP
+Test the C++ Couroutines compatibility with IncludeOS and SMP

--- a/test/stl/integration/coroutines/service.cpp
+++ b/test/stl/integration/coroutines/service.cpp
@@ -23,8 +23,9 @@
 #define SMP_DEBUG 1
 
 #include <os>
+#include <expects>
 #include <iostream>
-#include <experimental/coroutine>
+#include <coroutine>
 #include <smp>
 #include <vector>
 
@@ -32,7 +33,7 @@ using namespace std;
 template<typename T>
 struct smp_future {
   struct promise_type;
-  using handle_type = std::experimental::coroutine_handle<promise_type>;
+  using handle_type = std::coroutine_handle<promise_type>;
   handle_type coro;
 
 #ifdef INCLUDEOS_SMP_ENABLE
@@ -79,7 +80,7 @@ struct smp_future {
     return coro.done();
   }
 
-  void await_suspend(std::experimental::coroutine_handle<> awaiting) {
+  void await_suspend(std::coroutine_handle<> awaiting) {
     CPULOG("await_suspend: spinwaiting for coro \n");
     while(!done);
     CPULOG("await_suspend: spinwaiting done, resuming awaiting coro \n");
@@ -111,16 +112,16 @@ struct smp_future {
     }
     auto initial_suspend() {
       //std::cout << "Started the coroutine, don't stop now!" << std::endl;
-      return std::experimental::suspend_always{};
+      return std::suspend_always{};
     }
     auto return_value(T v) {
       //std::cout << "Got an answer of " << v << std::endl;
       value = v;
-      return std::experimental::suspend_never{};
+      return std::suspend_never{};
     }
-    auto final_suspend() {
+    auto final_suspend() noexcept {
       //std::cout << "Finished the coro" << std::endl;
-      return std::experimental::suspend_always{};
+      return std::suspend_always{};
     }
 
 
@@ -131,12 +132,12 @@ struct smp_future {
 };
 
 
-smp_future<int> answer(int i) {
+smp_future<int> answer(int i) noexcept {
   CPULOG("Computing answer for %i \n", i);
   co_return i * 2;
 }
 
-smp_future<int> reduce() {
+smp_future<int> reduce() noexcept {
 
 
   std::vector< decltype(answer(10)) > futures;
@@ -182,7 +183,7 @@ smp_future<int> reduce() {
   co_return sum;
 }
 
-smp_future<int> reduce1 () {
+smp_future<int> reduce1 () noexcept {
   co_return co_await answer(1);
 }
 

--- a/unittests.nix
+++ b/unittests.nix
@@ -18,34 +18,10 @@ stdenv.mkDerivation rec {
     ./lib
     ];
 
-  lest = stdenv.mkDerivation rec {
-    pname = "lest";
-    version = "1.35.2";
-
-    meta = {
-      description = "A tiny C++11 test framework – lest errors escape testing.";
-      homepage = "https://github.com/martinmoene/lest";
-      license = pkgs.lib.licenses.boost;
-    };
-
-    src = fetchGit {
-      url = "https://github.com/martinmoene/lest.git";
-      rev = "1eda2f7c33941617fc368ce764b5fbeffccb59bc";
-    };
-
-    cmakeBuildType = "Debug";
-
-    postBuild = ''
-      mkdir -p "$out/include"
-      cp -r include "$out/"
-    '';
-
-  };
-
   hardeningDisable = [ "all" ];
-
   cmakeBuildType = "Debug";
 
+  lest = pkgs.callPackage ./deps/lest {};
   uzlib = pkgs.callPackage ./deps/uzlib {};
 
   passthru = {


### PR DESCRIPTION
- Moves lest to its own nix file, allowing it to be used in integration tests
- Adds a vmrunner parameter to shell.nix, for vmrunner development 
- Fixes coroutines test
- Add a new test category to test.sh, STL, that tests aspects of the C and C++ runtimes

Result of `./test.sh`: 
```
🌈✨ Everything is awesome ✨
```