### PR TITLE
nix: add optional ccache support

### DIFF
--- a/chainloader.nix
+++ b/chainloader.nix
@@ -1,6 +1,11 @@
-{ nixpkgs ? ./pinned.nix,
+{
+  withCcache ? false, # Enable ccache. Requires /nix/var/cache/ccache to exist with correct permissions.
+
+  nixpkgs ? ./pinned.nix,
   overlays ? [
-    (import ./overlay.nix)
+    (import ./overlay.nix {
+      inherit withCcache;
+    })
   ],
   pkgs ? import nixpkgs {
       config = { };
@@ -9,7 +14,6 @@
         config = "i686-unknown-linux-musl";
       };
   },
-  llvmPkgs ? pkgs.llvmPackages_18
 }:
 let
   includeos = pkgs.pkgsIncludeOS.includeos;

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,8 @@
-{ nixpkgs ? ./pinned.nix,
+{ withCcache ? false, # Enable ccache. Requires correct permissions, see overlay.nix.
+
+  nixpkgs ? ./pinned.nix,
   overlays ? [
-    (import ./overlay.nix)
+    (import ./overlay.nix { inherit withCcache; } )
   ],
   pkgs ? import nixpkgs { config = {}; inherit overlays; }
 }:

--- a/example.nix
+++ b/example.nix
@@ -1,5 +1,7 @@
-{ nixpkgs ? ./pinned.nix,
-  includeos ? import ./default.nix { },
+{ withCcache ? false,
+
+  nixpkgs ? ./pinned.nix,
+  includeos ? import ./default.nix { inherit withCcache; },
   pkgs ? (import nixpkgs { }).pkgsStatic,
   llvmPkgs ? pkgs.llvmPackages_18
 }:

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,4 +1,8 @@
+{
+  withCcache, # Enable ccache. Requires correct permissions, see below.
+} :
 final: prev: {
+
   stdenvIncludeOS = prev.pkgsStatic.lib.makeScope prev.pkgsStatic.newScope (self: {
     llvmPkgs = prev.pkgsStatic.llvmPackages_18;
     stdenv = self.llvmPkgs.libcxxStdenv; # Use this as base stdenv
@@ -62,6 +66,32 @@ final: prev: {
     http-parser = self.callPackage ./deps/http-parser/default.nix { };
     vmbuild = self.callPackage ./vmbuild.nix { };
 
+    ccacheWrapper = prev.ccacheWrapper.override {
+        inherit (self.stdenv) cc;
+        extraConfig = ''
+          export CCACHE_COMPRESS=1
+          export CCACHE_DIR="/nix/var/cache/ccache"
+          export CCACHE_UMASK=007
+          export CCACHE_SLOPPINESS=random_seed
+          if [ ! -d "$CCACHE_DIR" ]; then
+            echo "====="
+            echo "Directory '$CCACHE_DIR' does not exist"
+            echo "Please create it with:"
+            echo "  sudo mkdir -m0770 '$CCACHE_DIR'"
+            echo "  sudo chown root:nixbld '$CCACHE_DIR'"
+            echo "====="
+            exit 1
+          fi
+          if [ ! -w "$CCACHE_DIR" ]; then
+            echo "====="
+            echo "Directory '$CCACHE_DIR' is not accessible for user $(whoami)"
+            echo "Please verify its access permissions"
+            echo "====="
+            exit 1
+          fi
+        '';
+      };
+
     # IncludeOS
     includeos = self.stdenv.mkDerivation rec {
       enableParallelBuilding = true;
@@ -92,7 +122,7 @@ final: prev: {
       nativeBuildInputs = [
         prev.buildPackages.cmake
         prev.buildPackages.nasm
-      ];
+      ] ++ prev.lib.optionals withCcache [self.ccacheWrapper];
 
       buildInputs = [
         self.botan2

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,4 @@
-{ nixpkgs ? ./pinned.nix,
-  overlays ? [ (import ./overlay.nix) ],
-  chainloader ? (import ./chainloader.nix {}),
-  pkgs ? import nixpkgs {
-    config = {};
-    inherit overlays;
-  },
+{
   # Will create a temp one if none is passed, for example:
   # nix-shell --argstr buildpath .
   buildpath ? "",
@@ -13,7 +7,18 @@
   unikernel ? "./example",
 
   # vmrunner path, for vmrunner development
-  vmrunner ? ""
+  vmrunner ? "",
+
+  # Enable ccache support. See overlay.nix for details.
+  withCcache ? false,
+
+  nixpkgs ? ./pinned.nix,
+  overlays ? [ (import ./overlay.nix { inherit withCcache; }) ],
+  chainloader ? (import ./chainloader.nix { inherit withCcache; }),
+  pkgs ? import nixpkgs {
+    config = {};
+    inherit overlays;
+  },
 }:
 pkgs.mkShell rec {
   includeos = pkgs.pkgsIncludeOS.includeos;


### PR DESCRIPTION
Adds a new attribute `withCcache` that defaults to false. When enabled, a wrapper around clang/clang++ will be added to the IncludeOS build environment.

With an existing cache, this reduces the service build time to about 1/5 on my server when the kernel also has to be rebuilt.

The directory used for caching is /nix/var/cache/ccache and it has to exist with the right permissions. See overlay.nix for additional details.

To enable ccache, pass "--arg withCcache true" to either nix-build or nix-shell.

To manage the ccache, install "ccache" locally. Then "sudo ccache --dir /nix/var/cache/ccache --show-stats" will show cache statistics and "sudo ccache --dir /nix/var/cache/ccache --clear" will clear the cache.

Ccache is currently disabled on unittests and integration tests to make sure that these are built from a clean environment.