### PR TITLE
Restore basic SMP support

### DIFF
--- a/api/kernel/rng.hpp
+++ b/api/kernel/rng.hpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cstdint>
 #include <delegate>
+#include <smp_utils>
 
 // Incorporate seed data into the system RNG state
 extern void rng_absorb(const void* input, size_t bytes);
@@ -54,14 +55,18 @@ class RNG : public FD_compatible {
 public:
   static RNG& get()
   {
-    static RNG rng;
+#ifdef INCLUDEOS_SMP_ENABLE
+    static Spinlock lock_;
+    std::lock_guard<Spinlock> lock(lock_);
+#endif
+    static RNG rng = RNG();
     return rng;
   }
 
   static void init();
 
 private:
-  RNG() {}
+  RNG() {};
 
 };
 

--- a/api/smp
+++ b/api/smp
@@ -52,7 +52,7 @@ public:
   static int cpu_count() noexcept;
 
   // Return the indices of all initialized CPU cores
-  static const std::vector<int>& active_cpus();
+  static const std::pmr::vector<int>& active_cpus();
 
   static int active_cpus(int index){
     return active_cpus().at(index);

--- a/src/kernel/events.cpp
+++ b/src/kernel/events.cpp
@@ -24,10 +24,12 @@
 //#define DEBUG_SMP
 
 static SMP::Array<Events> managers;
+static Spinlock em_lock_;
 
 Events& Events::get(int cpuid)
 {
 #ifdef INCLUDEOS_SMP_ENABLE
+  std::lock_guard<Spinlock> guard(em_lock_);
   return managers.at(cpuid);
 #else
   (void) cpuid;
@@ -36,6 +38,10 @@ Events& Events::get(int cpuid)
 }
 Events& Events::get()
 {
+#ifdef INCLUDEOS_SMP_ENABLE
+  static Spinlock lock;
+  std::lock_guard<Spinlock> guard(em_lock_);
+#endif
   return PER_CPU(managers);
 }
 

--- a/src/kernel/profile.cpp
+++ b/src/kernel/profile.cpp
@@ -80,6 +80,10 @@ struct Sampler
 };
 
 static Sampler& get() {
+#ifdef INCLUDEOS_SMP_ENABLE
+  static Spinlock lock;
+  std::lock_guard<Spinlock> guard(lock);
+#endif
   static Sampler sampler;
   return sampler;
 }

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -192,10 +192,14 @@ void os::panic(const char* why) noexcept
 extern "C"
 void double_fault(const char* why)
 {
+#ifdef INCLUDEOS_SMP_ENABLE
   SMP::global_lock();
+#endif
   fprintf(stderr, "\n\n%s\nDouble fault! \nCPU: %d, Reason: %s\n",
           panic_signature, SMP::cpu_id(), why);
+#ifdef INCLUDEOS_SMP_ENABLE
   SMP::global_unlock();
+#endif
 
   panic_epilogue(why);
 }
@@ -213,10 +217,14 @@ void panic_epilogue(const char* why)
   }
 
 #if defined(ARCH_x86)
+#ifdef INCLUDEOS_SMP_ENABLE
   SMP::global_lock();
+#endif
   // Signal End-Of-Transmission
   kprint("\x04");
+#ifdef INCLUDEOS_SMP_ENABLE
   SMP::global_unlock();
+#endif
 
 #else
 #warning "panic() handler not implemented for selected arch"

--- a/src/kernel/timers.cpp
+++ b/src/kernel/timers.cpp
@@ -94,6 +94,10 @@ void timer_system::free_timer(Timers::id_t id)
 }
 
 static inline timer_system& get() {
+#ifdef INCLUDEOS_SMP_ENABLE
+  static Spinlock lock;
+  std::lock_guard<Spinlock> guard(lock);
+#endif
   return PER_CPU(systems);
 }
 

--- a/src/platform/x86_pc/acpi.hpp
+++ b/src/platform/x86_pc/acpi.hpp
@@ -61,10 +61,10 @@ namespace x86 {
       uint8_t   lint;
     } __attribute__((packed));
 
-    typedef std::vector<LAPIC> lapic_list;
-    typedef std::vector<IOAPIC> ioapic_list;
-    typedef std::vector<override_t> override_list;
-    typedef std::vector<nmi_t>  nmi_list;
+    typedef std::pmr::vector<LAPIC> lapic_list;
+    typedef std::pmr::vector<IOAPIC> ioapic_list;
+    typedef std::pmr::vector<override_t> override_list;
+    typedef std::pmr::vector<nmi_t>  nmi_list;
 
     static void init() {
       get().discover();

--- a/src/platform/x86_pc/acpi.hpp
+++ b/src/platform/x86_pc/acpi.hpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <vector>
+#include <smp_utils>
 
 namespace x86 {
 
@@ -72,6 +73,10 @@ namespace x86 {
     static uint64_t time();
 
     static ACPI& get() {
+  #ifdef INCLUDEOS_SMP_ENABLE
+      static Spinlock lock;
+      std::lock_guard<Spinlock> guard(lock);
+  #endif
       static ACPI acpi;
       return acpi;
     }

--- a/src/platform/x86_pc/apic_revenant.cpp
+++ b/src/platform/x86_pc/apic_revenant.cpp
@@ -33,7 +33,7 @@ static bool revenant_task_doer(smp_system_stuff& system)
   }
 
   // create local vector which holds tasks
-  std::vector<smp_task> tasks;
+  std::pmr::vector<smp_task> tasks;
   system.tasks.swap(tasks);
 
   system.tlock.unlock();

--- a/src/platform/x86_pc/apic_revenant.hpp
+++ b/src/platform/x86_pc/apic_revenant.hpp
@@ -43,7 +43,7 @@ struct smp_stuff
   uintptr_t stack_size;
   minimal_barrier_t boot_barrier;
   uint32_t  bmp_storage[1] = {0};
-  std::vector<int> initialized_cpus {0};
+  std::pmr::vector<int> initialized_cpus {0};
   MemBitmap bitmap{&bmp_storage[0], 1};
 };
 
@@ -54,8 +54,8 @@ struct smp_system_stuff
 {
   Spinlock tlock;
   Spinlock flock;
-  std::vector<smp_task> tasks;
-  std::vector<SMP::done_func> completed;
+  std::pmr::vector<smp_task> tasks;
+  std::pmr::vector<SMP::done_func> completed;
   bool work_done;
 };
  extern SMP::Array<smp_system_stuff> smp_system;

--- a/src/platform/x86_pc/cpu_freq_sampling.cpp
+++ b/src/platform/x86_pc/cpu_freq_sampling.cpp
@@ -54,14 +54,14 @@ namespace x86 {
     auto t3 = os::cycles_since_boot();
     auto overhead = (t3 - t1) * 2;
 
-    std::vector<double> cpu_freq_samples;
+    std::array<double, CPU_FREQUENCY_SAMPLES> cpu_freq_samples;
 
     for (size_t i = 1; i < CPU_FREQUENCY_SAMPLES; i++){
       // Compute delta in cycles
       auto cycles = cpu_timestamps[i] - cpu_timestamps[i-1] + overhead;
       // Cycles pr. second == Hertz
       auto freq = cycles * test_frequency().count();
-      cpu_freq_samples.push_back(freq);
+      cpu_freq_samples[i] = freq;
     }
 
     std::sort(cpu_freq_samples.begin(), cpu_freq_samples.end());

--- a/src/platform/x86_pc/smp.cpp
+++ b/src/platform/x86_pc/smp.cpp
@@ -146,7 +146,7 @@ void init_SMP()
       // remove bit
       smp_main.bitmap.atomic_reset(next);
       // get jobs from other CPU
-      std::vector<smp_done_func> done;
+      std::pmr::vector<smp_done_func> done;
       smp_system[next].flock.lock();
       smp_system[next].completed.swap(done);
       smp_system[next].flock.unlock();
@@ -185,7 +185,7 @@ int SMP::cpu_id() noexcept
 int SMP::cpu_count() noexcept {
   return x86::smp_main.initialized_cpus.size();
 }
-const std::vector<int>& SMP::active_cpus() {
+const std::pmr::vector<int>& SMP::active_cpus() {
   return x86::smp_main.initialized_cpus;
 }
 

--- a/src/platform/x86_pc/smp.cpp
+++ b/src/platform/x86_pc/smp.cpp
@@ -30,6 +30,7 @@ extern "C" {
   extern char _binary_apic_boot_bin_start;
   extern char _binary_apic_boot_bin_end;
   extern void __apic_trampoline(); // 64-bit entry
+  extern void* kalloc_aligned(size_t, size_t);
 }
 
 static const uintptr_t BOOTLOADER_LOCATION = 0x10000;
@@ -82,7 +83,7 @@ void init_SMP()
   memcpy((char*) BOOTLOADER_LOCATION, start, bootl_size);
 
   // allocate revenant main stacks
-  void* stack = memalign(4096, CPUcount * REV_STACK_SIZE);
+  void* stack = kalloc_aligned(4096, CPUcount * REV_STACK_SIZE);
   smp_main.stack_base = (uintptr_t) stack;
   smp_main.stack_size = REV_STACK_SIZE;
 

--- a/src/platform/x86_pc/x2apic.hpp
+++ b/src/platform/x86_pc/x2apic.hpp
@@ -232,6 +232,10 @@ namespace x86 {
     }
 
     static x2apic& get() {
+#ifdef INCLUDEOS_SMP_ENABLE
+      static Spinlock lock;
+      std::lock_guard<Spinlock> guard(lock);
+#endif
       static x2apic instance;
       return instance;
     }

--- a/src/platform/x86_pc/xapic.hpp
+++ b/src/platform/x86_pc/xapic.hpp
@@ -224,6 +224,10 @@ namespace x86 {
     }
 
     static xapic& get() {
+#ifdef INCLUDEOS_SMP_ENABLE
+      static Spinlock lock;
+      std::lock_guard<Spinlock> guard(lock);
+#endif
       static xapic instance;
       return instance;
     }

--- a/test/kernel/integration/smp/test.py
+++ b/test/kernel/integration/smp/test.py
@@ -6,5 +6,17 @@ import os
 
 from vmrunner import vmrunner
 
-vmrunner.vms[0].boot(20,image_name='kernel_smp.elf.bin')
-#vm.cmake(["-Dsingle_threaded=OFF"]).boot(20).clean()
+boot_count = 0
+success = False
+
+def booted(line):
+    global boot_count
+    boot_count += 1;
+    if boot_count > 1:
+        vm.exit(1, "VM rebooted unexpectedly")
+
+vm = vmrunner.vms[0]
+
+vm.on_output("#include<os> // Literally", booted);
+
+vm.boot(20,image_name='kernel_smp.elf.bin')


### PR DESCRIPTION
This restores basic SMP-support. The main change is that the kernel now uses explicit spinlocks for static variables initialised with get()-methods. This is necessary after we disabled threadsafe statics (which may not have worked properly in the past, as libc wasn't initialised).

I've updated the default PMR allocator to be SMP safe and replaced most of the dynamic datastructures in SMP/APIC with PMR-versions. This avoids calls through libc, although the allocator itself could probably be made more efficient.

The SMP test now only tests for tasks running on different cores and does a malloc/stack/PMR allocation test. We don't support printf or timers from different cores yet.

Without the locks the initialisation of the SMP cores would occasionally crash and reboot or the test itself would deadlock. I've run this 40-50 times with 16 cores now without a crash, but it would be very useful with a read-through by someone familiar with the code and AP init to double check that it makes sense!

Bonus:
- Cherrypicked nanosleep syscall implementation by fwsGonzo from f9828aed29e57e72c0eb9b8c785152c8b7135d3d

Some other changes that may be useful to bring in later:
- https://github.com/includeos/IncludeOS/commit/47f6702aefb7f007f3f2764dff7becc01e036dfd
- https://github.com/includeos/IncludeOS/commit/6944de0ececd7e842d7a050afcb8300765750a84
- https://github.com/includeos/IncludeOS/commit/330432b39d41b9804437f3fc18182c17b24d57ba