### PR TITLE
Add support for cmake find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.6)
 
 #we are only creating libraries for ELF
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
@@ -16,6 +16,14 @@ add_subdirectory(src)
 install(FILES cmake/linux.service.cmake DESTINATION cmake)
 install(FILES cmake/os.cmake DESTINATION cmake)
 install(FILES cmake/includeos.cmake DESTINATION cmake)
+
+# Install config to enable find_package(IncludeOS)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  cmake/includeos-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/includeos-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/includeos-config.cmake DESTINATION cmake)
 
 # Install IncludeOS user code dependencies
 install(FILES src/service_name.cpp DESTINATION src)

--- a/cmake/includeos-config.cmake.in
+++ b/cmake/includeos-config.cmake.in
@@ -1,0 +1,5 @@
+# Config file to be picked up by find_package()
+@PACKAGE_INIT@
+set(ARCH "x86_64")
+set(INCLUDEOS_PACKAGE @CMAKE_INSTALL_PREFIX@)
+set(CMAKE_MODULE_PATH @CMAKE_INSTALL_PREFIX@/cmake)

--- a/example.nix
+++ b/example.nix
@@ -22,18 +22,5 @@ includeos.stdenv.mkDerivation rec {
     includeos
   ];
 
-  # TODO:
-  # We currently need to explicitly pass in because we link with a linker script
-  # and need to control linking order.
-  # This can be moved to os.cmake eventually, once we figure out how to expose
-  # them to cmake from nix without having to make cmake depend on nix.
-  # * Maybe we should make symlinks from the includeos package to them.
-
-  cmakeFlags = [
-    "-DINCLUDEOS_PACKAGE=${includeos}"
-    "-DARCH=x86_64"
-    "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
-  ];
-
   version = "dev";
 }

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.6)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-
 
 project(hello_includeos)
 
-include("${INCLUDEOS_PACKAGE}/cmake/os.cmake")
+find_package(IncludeOS)
+
+include(os)
 
 os_add_executable(hello_includeos "Hello world - OS included" src/main.cpp)
 os_add_drivers(hello_includeos virtionet vmxnet3 boot_logger)


### PR DESCRIPTION
Enables `find_package()` from other nix-installed packages by adding `cmake/includeos-config.cmake.in` template, which is then installed to `cmake/includeos-config.cmake` with the correct paths filled in. This avoids the cmake flags that previously had to be set manually. Updates `example.nix` to use the new method.
