### PR TITLE
Revive Fieldmedic plugin, add early kernel diagnostic hooks 

### DIFF
--- a/api/info
+++ b/api/info
@@ -29,7 +29,7 @@
 #define INFO2(TEXT, ...) kprintf("%16s" TEXT "\n"," ", ##__VA_ARGS__)
 #define CENTER(TEXT) kprintf("%*s%*s\n",LINEWIDTH/2 + (int)strlen(TEXT)/2,TEXT,LINEWIDTH/2-(int)strlen(TEXT)/2,"")
 #include <string>
-#define FILLINE(CHAR) kprintf("%s\n",std::string(LINEWIDTH,CHAR).c_str())
+#define FILLINE(CHAR) kprintf("%s\n",std::pmr::string(LINEWIDTH,CHAR).c_str())
 #define CAPTION(TEXT) FILLINE('='); kprintf("\n"); CENTER(TEXT); kprintf("\n"); FILLINE('=')
 
 // Checkboxes - for initialization output and testing

--- a/api/info
+++ b/api/info
@@ -21,19 +21,21 @@
 
 #define LINEWIDTH 80
 
+#include <kprint>
+
 // Informational prints
 #ifndef NO_INFO
-#define INFO(FROM, TEXT, ...) printf("%13s ] " TEXT "\n", "[ " FROM, ##__VA_ARGS__)
-#define INFO2(TEXT, ...) printf("%16s" TEXT "\n"," ", ##__VA_ARGS__)
-#define CENTER(TEXT) printf("%*s%*s\n",LINEWIDTH/2 + (int)strlen(TEXT)/2,TEXT,LINEWIDTH/2-(int)strlen(TEXT)/2,"")
+#define INFO(FROM, TEXT, ...) kprintf("%13s ] " TEXT "\n", "[ " FROM, ##__VA_ARGS__)
+#define INFO2(TEXT, ...) kprintf("%16s" TEXT "\n"," ", ##__VA_ARGS__)
+#define CENTER(TEXT) kprintf("%*s%*s\n",LINEWIDTH/2 + (int)strlen(TEXT)/2,TEXT,LINEWIDTH/2-(int)strlen(TEXT)/2,"")
 #include <string>
-#define FILLINE(CHAR) printf("%s\n",std::string(LINEWIDTH,CHAR).c_str())
-#define CAPTION(TEXT) FILLINE('='); printf("\n"); CENTER(TEXT); printf("\n"); FILLINE('=')
+#define FILLINE(CHAR) kprintf("%s\n",std::string(LINEWIDTH,CHAR).c_str())
+#define CAPTION(TEXT) FILLINE('='); kprintf("\n"); CENTER(TEXT); kprintf("\n"); FILLINE('=')
 
 // Checkboxes - for initialization output and testing
-#define CHECK(TEST, TEXT, ...) printf("%16s[%s] " TEXT "\n","", TEST ? "x" : " ",  ##__VA_ARGS__)
+#define CHECK(TEST, TEXT, ...) kprintf("%16s[%s] " TEXT "\n","", TEST ? "x" : " ",  ##__VA_ARGS__)
 #define CHECKSERT(TEST, TEXT, ...) CHECK(TEST, TEXT, ##__VA_ARGS__), assert(TEST)
-#define FAIL(TEXT, ...)  printf("FAIL: " TEXT "\n", ##__VA_ARGS__); os::panic("FAIL")
+#define FAIL(TEXT, ...)  kprintf("FAIL: " TEXT "\n", ##__VA_ARGS__); os::panic("FAIL")
 
 // Undefine
 #else

--- a/api/kernel/diag.hpp
+++ b/api/kernel/diag.hpp
@@ -1,0 +1,22 @@
+#ifndef KERNEL_DIAG_HOOKS_HPP
+#define KERNEL_DIAG_HOOKS_HPP
+#define RUN_DIAG_HOOKS true
+
+constexpr bool run_diag_hooks = RUN_DIAG_HOOKS;
+
+namespace kernel::diag {
+  void post_bss() noexcept;
+  void post_machine_init() noexcept;
+  void post_init_libc() noexcept;
+
+  void default_post_init_libc() noexcept;
+
+  template <auto Func>
+  void hook() {
+    if constexpr (run_diag_hooks) {
+      Func();
+    }
+  }
+}
+
+#endif

--- a/api/kernel/diag.hpp
+++ b/api/kernel/diag.hpp
@@ -8,6 +8,7 @@ namespace kernel::diag {
   void post_bss() noexcept;
   void post_machine_init() noexcept;
   void post_init_libc() noexcept;
+  void post_service() noexcept;
 
   void default_post_init_libc() noexcept;
 

--- a/src/kernel/kernel.cpp
+++ b/src/kernel/kernel.cpp
@@ -18,6 +18,7 @@
 #include <os.hpp>
 #include <kernel.hpp>
 #include <kernel/cpuid.hpp>
+#include <kernel/diag.hpp>
 #include <kernel/rng.hpp>
 #include <service>
 #include <cstdio>
@@ -168,6 +169,7 @@ void kernel::post_start()
 
   // service program start
   Service::start();
+  kernel::diag::hook<kernel::diag::post_service>();
 }
 
 void os::add_stdout(os::print_func func)
@@ -227,3 +229,5 @@ void os::print_timestamps(const bool enabled)
 {
   kernel::state().timestamps = enabled;
 }
+
+void __attribute__((weak)) kernel::diag::post_service() noexcept {}

--- a/src/kernel/syscalls.cpp
+++ b/src/kernel/syscalls.cpp
@@ -252,7 +252,7 @@ void kernel::default_exit() {
 }
 
 extern "C"
-void _init_syscalls()
+void __init_crash_contexts()
 {
   // make sure each buffer is zero length so it won't always show up in crashes
   for (auto& ctx : contexts)

--- a/src/platform/aarch64_vm/kernel_start.cpp
+++ b/src/platform/aarch64_vm/kernel_start.cpp
@@ -129,14 +129,14 @@ extern "C" {/*
   uintptr_t _move_symbols(uintptr_t loc);
 //  void _init_bss();
   void _init_heap(uintptr_t);
-  void _init_syscalls();
+  void __init_crash_contexts();
 */
   void __init_sanity_checks();
   void kernel_sanity_checks();
   void _init_bss();
   uintptr_t _move_symbols(uintptr_t loc);
   void _init_elf_parser();
-  void _init_syscalls();
+  void __init_crash_contexts();
   void __elf_validate_section(const void*);
 }
 
@@ -241,7 +241,7 @@ void kernel_start(uintptr_t magic, uintptr_t addrin)
   __machine->init();
 
   // Initialize system calls
-  _init_syscalls();
+  __init_crash_contexts();
 
   //probably not very sane!
   cpu_debug_enable();

--- a/src/platform/x86_nano/kernel_start.cpp
+++ b/src/platform/x86_nano/kernel_start.cpp
@@ -27,7 +27,7 @@ extern "C" {
   uintptr_t _move_symbols(uintptr_t loc);
   void _init_heap(uintptr_t);
   void _init_elf_parser();
-  void _init_syscalls();
+  void __init_crash_contexts();
 }
 
 uintptr_t _multiboot_free_begin(uintptr_t boot_addr);
@@ -61,7 +61,7 @@ void kernel_start(uintptr_t magic, uintptr_t addr)
   _init_elf_parser();
 
   // Initialize system calls
-  _init_syscalls();
+  __init_crash_contexts();
 
   // Initialize stdout handlers
   if (os_default_stdout)

--- a/src/platform/x86_pc/kernel_start.cpp
+++ b/src/platform/x86_pc/kernel_start.cpp
@@ -37,7 +37,7 @@ extern "C" {
   void _init_bss();
   uintptr_t _move_symbols(uintptr_t loc);
   void _init_elf_parser();
-  void _init_syscalls();
+  void __init_crash_contexts();
   void __elf_validate_section(const void*);
 }
 
@@ -108,7 +108,7 @@ void kernel_start(uint32_t magic, uint32_t addr)
   RNG::init();
 
   PRATTLE("* Init syscalls\n");
-  _init_syscalls();
+  __init_crash_contexts();
 
   PRATTLE("* Init CPU exceptions\n");
   x86::idt_initialize_for_cpu(0);

--- a/src/platform/x86_pc/kernel_start.cpp
+++ b/src/platform/x86_pc/kernel_start.cpp
@@ -16,6 +16,7 @@
 
 #include <kernel.hpp>
 #include <kernel/rng.hpp>
+#include <kernel/diag.hpp>
 #include <os.hpp>
 #include <boot/multiboot.h>
 #include <kprint>
@@ -26,9 +27,9 @@
 
 //#define KERN_DEBUG 1
 #ifdef KERN_DEBUG
-#define PRATTLE(fmt, ...) kprintf(fmt, ##__VA_ARGS__)
+#define KDEBUG(fmt, ...) kprintf(fmt, ##__VA_ARGS__)
 #else
-#define PRATTLE(fmt, ...) /* fmt */
+#define KDEBUG(fmt, ...) /* fmt */
 #endif
 
 extern "C" {
@@ -39,6 +40,11 @@ extern "C" {
   void _init_elf_parser();
   void __init_crash_contexts();
   void __elf_validate_section(const void*);
+}
+
+namespace kernel::diag {
+  void __attribute__((weak)) post_bss() noexcept {}
+  void __attribute__((weak)) post_machine_init() noexcept {}
 }
 
 uintptr_t _multiboot_free_begin(uintptr_t bootinfo);
@@ -57,18 +63,22 @@ os::Machine& os::machine() noexcept {
   return *__machine;
 }
 
+const char* os::Machine::name() noexcept {
+  return "x86 PC";
+}
+
 // x86 kernel start
 extern "C"
 __attribute__((no_sanitize("all")))
 void kernel_start(uint32_t magic, uint32_t addr)
 {
-  PRATTLE("\n//////////////////  IncludeOS kernel start ////////////////// \n");
-  PRATTLE("* Booted with magic 0x%x, grub @ 0x%x \n",
+  KDEBUG("\n//////////////////  IncludeOS kernel start ////////////////// \n");
+  KDEBUG("* Booted with magic 0x%x, grub @ 0x%x \n",
           magic, addr);
   // generate checksums of read-only areas etc.
   __init_sanity_checks();
 
-  PRATTLE("* Grub magic: 0x%x, grub info @ 0x%x\n", magic, addr);
+  KDEBUG("* Grub magic: 0x%x, grub info @ 0x%x\n", magic, addr);
 
   // Determine where free memory starts
   extern char _end;
@@ -83,34 +93,36 @@ void kernel_start(uint32_t magic, uint32_t addr)
   {
     memory_end = kernel::softreset_memory_end(addr);
   }
-  PRATTLE("* Free mem begin: 0x%zx, memory end: 0x%zx \n",
+  KDEBUG("* Free mem begin: 0x%zx, memory end: 0x%zx \n",
           free_mem_begin, memory_end);
 
-  PRATTLE("* Moving symbols. \n");
+  KDEBUG("* Moving symbols. \n");
   // Preserve symbols from the ELF binary
   free_mem_begin += _move_symbols(free_mem_begin);
-  PRATTLE("* Free mem moved to: %p \n", (void*) free_mem_begin);
+  KDEBUG("* Free mem moved to: %p \n", (void*) free_mem_begin);
 
-  PRATTLE("* Init .bss\n");
+  KDEBUG("* Init .bss\n");
   _init_bss();
+  kernel::diag::hook<kernel::diag::post_bss>();
 
   // Instantiate machine
   size_t memsize = memory_end - free_mem_begin;
   __machine = os::Machine::create((void*)free_mem_begin, memsize);
 
-  PRATTLE("* Init ELF parser\n");
+  KDEBUG("* Init ELF parser\n");
   _init_elf_parser();
 
   // Begin portable HAL initialization
   __machine->init();
+  kernel::diag::hook<kernel::diag::post_machine_init>();
 
   // TODO: Move more stuff into Machine::init
   RNG::init();
 
-  PRATTLE("* Init syscalls\n");
+  KDEBUG("* Init per CPU crash contexts\n");
   __init_crash_contexts();
 
-  PRATTLE("* Init CPU exceptions\n");
+  KDEBUG("* Init CPU exceptions\n");
   x86::idt_initialize_for_cpu(0);
 
   x86::init_libc(magic, addr);

--- a/src/platform/x86_solo5/kernel_start.cpp
+++ b/src/platform/x86_solo5/kernel_start.cpp
@@ -10,7 +10,7 @@ extern "C" {
 extern "C" {
   void __init_sanity_checks();
   uintptr_t _move_symbols(uintptr_t loc);
-  void _init_syscalls();
+  void __init_crash_contexts();
   void _init_elf_parser();
 }
 
@@ -59,7 +59,7 @@ void kernel_start()
   __machine->init();
 
   // Initialize system calls
-  _init_syscalls();
+  __init_crash_contexts();
 
   x86::init_libc((uint32_t) (uintptr_t) temp_cmdline, 0);
 }

--- a/src/plugins/field_medic/diag.cpp
+++ b/src/plugins/field_medic/diag.cpp
@@ -20,8 +20,7 @@
 #include <expects>
 #include "fieldmedic.hpp"
 
-namespace medic {
-namespace diag {
+namespace medic::diag {
 
   thread_local std::array<char, diag::bufsize> __tl_bss;
   thread_local std::array<int, 256> __tl_data {
@@ -130,5 +129,4 @@ namespace diag {
     return check1 == check2 - 90;
   }
 
-}
 }

--- a/src/plugins/field_medic/diag.cpp
+++ b/src/plugins/field_medic/diag.cpp
@@ -16,9 +16,98 @@
 
 #include <stdexcept>
 #include <cstdlib>
-#include <os>
 #include <expects>
+#include <kernel/diag.hpp>
+#include <kprint>
+#include <os>
+#include <hal/machine.hpp>
 #include "fieldmedic.hpp"
+
+static int diag_bss_arr[1024]{};
+static char* heap_42s = nullptr;
+static std::span<int> machine_ints;
+
+#define KINFO(FROM, TEXT, ...) kprintf("%13s ] " TEXT "\n", "[ " FROM, ##__VA_ARGS__)
+#define MYINFO(X,...) KINFO("Field Medic","⛑️  " X,##__VA_ARGS__)
+
+
+using namespace medic::diag;
+
+/** Toggles indicating the hook was called by the OS */
+static bool diag_post_bss = false;
+static bool diag_post_machine_init = false;
+static bool diag_post_init_libc = false;
+
+/** Diagnostic hook overrides */
+void kernel::diag::post_bss() noexcept {
+  diag_post_bss = true;
+  Expects(invariant_post_bss());
+  MYINFO("BSS Diagnostic passed");
+}
+
+bool medic::diag::invariant_post_bss(){
+  for (int i : diag_bss_arr) {
+    Expects(i == 0);
+  }
+  return diag_post_bss;
+}
+
+void kernel::diag::post_machine_init() noexcept {
+  auto mem = (char*)os::machine().memory().allocate(1024);
+  Expects(mem != nullptr);
+  os::machine().memory().deallocate(mem, 1024);
+
+  os::Machine::Allocator<int> alloc;
+  machine_ints = std::span<int>(alloc.allocate(40), 40);
+  int j = 0;
+
+  for(auto& i : machine_ints){
+    i = j++;
+  }
+
+  MYINFO("Machine allocator for %s functional", os::machine().name());
+  diag_post_machine_init = true;
+
+  Expects(invariant_post_machine_init());
+}
+
+
+bool medic::diag::invariant_post_machine_init(){
+  int j = 0;
+
+  for(auto& i : machine_ints){
+    Expects(i == j++);
+  }
+  return diag_post_machine_init;
+}
+
+void kernel::diag::post_init_libc() noexcept {
+
+  default_post_init_libc();
+  MYINFO("Elf header intact, global constructors functional");
+
+  heap_42s = (char*)malloc(1024);
+  Expects(heap_42s != nullptr);
+
+  std::span<char> chars(heap_42s, 1024);
+
+  for(auto& c : chars){
+    c = 42;
+  }
+  MYINFO("Malloc and brk are functional");
+  diag_post_init_libc = true;
+  Expects(invariant_post_init_libc());
+}
+
+bool medic::diag::invariant_post_init_libc(){
+  std::span<char> chars(heap_42s, 1024);
+
+  for(auto& c : chars){
+    Expects(c == 42);
+  }
+
+  return diag_post_init_libc;
+}
 
 namespace medic::diag {
 

--- a/src/plugins/field_medic/fieldmedic.cpp
+++ b/src/plugins/field_medic/fieldmedic.cpp
@@ -40,12 +40,6 @@ namespace medic{
   void init(){
     using namespace diag;
     MYINFO("Checking vital signs");
-    printf(
-           "\t         ____n_\n"
-           "\t------  | +  |_\\-; ---------\n"
-           "\t ====== ;@-----@-'  ===========\n"
-           "\t  _______________________________\n\n"
-           );
 
     /* TODO:
        DIAGNOSE(timers(),     "Timers active");
@@ -60,9 +54,9 @@ namespace medic{
     DIAGNOSE(exceptions(), "Exceptions test");
 
     if (diag_failures == 0){
-      MYINFO("Diagnose complete: Healthy ✅");
+      MYINFO("OS initialization: All checks passed ✅");
     } else {
-      MYINFO("Diagnose complete: %i / %i checks failed", diag_failures, (diag_failures + diag_successes));
+      MYINFO("OS initialization: %i / %i checks failed", diag_failures, (diag_failures + diag_successes));
     }
   }
 

--- a/src/plugins/field_medic/fieldmedic.cpp
+++ b/src/plugins/field_medic/fieldmedic.cpp
@@ -108,7 +108,7 @@ void kernel::diag::post_service() noexcept {
   DIAGNOSE(invariant_post_init_libc(), "Post init libc invariant still holds");
 
   if (diag_failures == 0){
-    MYINFO("Diagnose complete. Healthy  ✅");
+    MYINFO("Diagnose complete. Healthy ✅");
   } else {
     MYINFO("Diagnose complete: %i / %i checks failed", diag_failures, (diag_failures + diag_successes));
   }

--- a/src/plugins/field_medic/fieldmedic.hpp
+++ b/src/plugins/field_medic/fieldmedic.hpp
@@ -26,6 +26,7 @@
 
 #include <array>
 #include <stdexcept>
+#include <kernel/diag.hpp>
 
 namespace medic{
   namespace diag
@@ -52,5 +53,12 @@ namespace medic{
     using Tl_bss_arr  = std::array<char, bufsize>;
     using Tl_data_arr = std::array<int, 256>;
 
+    /**
+     * Global invariants expected to return true forever after
+     * the respective hooks have been run.
+     */
+    bool invariant_post_bss();
+    bool invariant_post_machine_init();
+    bool invariant_post_init_libc();
   }
 }

--- a/test/kernel/integration/osinit/CMakeLists.txt
+++ b/test/kernel/integration/osinit/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.6)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+project (service)
+include(os)
+
+set(SOURCES
+    service.cpp
+)
+
+os_add_executable(osinit "OS initialization test" ${SOURCES})
+os_add_stdout(osinit default_stdout)
+os_add_drivers(osinit boot_logger)
+os_add_plugins(osinit field_medic)
+
+configure_file(test.py ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/kernel/integration/osinit/service.cpp
+++ b/test/kernel/integration/osinit/service.cpp
@@ -1,0 +1,7 @@
+#include <service>
+#include <kprint>
+
+void Service::start()
+{
+  kprint("Service::start entered\n");
+}

--- a/test/kernel/integration/osinit/test.py
+++ b/test/kernel/integration/osinit/test.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+from vmrunner import vmrunner
+vm = vmrunner.vms[0]
+
+
+def done(line):
+    if "Healthy" in line:
+        vm.exit(0, "OS initialization test succeeded")
+    elif "failed" in line:
+        status = line.split(":")[1].strip()
+        vm.exit(1, status)
+    else:
+        vm.exit(2, "OS initialization test failed")
+
+vm.on_output("Diagnose complete", done)
+
+
+vm.boot(20, image_name='osinit.elf.bin')

--- a/test/lest_util/os_mock.cpp
+++ b/test/lest_util/os_mock.cpp
@@ -67,6 +67,7 @@ void Service::ready()
   printf("Service::ready() called\n");
 }
 
+__attribute__ ((format (printf, 1, 2)))
 extern "C"
 void kprintf(const char* format, ...)
 {
@@ -77,9 +78,9 @@ void kprintf(const char* format, ...)
 }
 
 extern "C"
-void kprint(char* str)
+void kprint(const char* str)
 {
-printf("%s", str);
+  printf("%s", str);
 }
 
 #include <os.hpp>
@@ -157,8 +158,8 @@ extern "C" {
     printf("<serial print1> %s\n", cstr);
   }
 
-  void __serial_print(const char* cstr, int len) {
-    printf("<serial print> %.*s", len, cstr);
+  void __serial_print(const char* cstr, size_t len) {
+    printf("<serial print> %.*s", static_cast<int>(len), cstr);
   }
 } // ~ extern "C"
 


### PR DESCRIPTION
The intention is to create a reusable pattern for kernel self tests and diagnostics that costs nothing default. We have quite a few defensive validation steps in the kernel added organically as issues have been found. Ideally a fast booting kernel should always do the correct thing without having to validate. In practice, validation is crucial. 

With this proposed setup we can optionally add a validation plugin (fieldmedic) that performs more extensive self tests after key checkpoints in the unikernel lifetime has been reached, with negligible cost in the default case (the cost of an empty function call per hook) and with zero cost when toggled off at compile time.

See commit messages for details. 

To try it out: 
```
$ nix-shell ~/IncludeOS/shell.nix --pure  --argstr unikernel ~/IncludeOS/test/kernel/integration/osinit --run ./test.py
...
<vm> <Multiboot>OS loaded with 1 modules
<vm> 	* osinit.elf.bin booted with vmrunner @ 0x29e000 - 0x43f6c0, size: 1709760b
<vm> * Multiboot begin: 0x9500
<vm> * Multiboot end: 0x3e5490
<vm> [ Field Medic ] ⛑️  BSS Diagnostic passed
<vm> [x86_64 PC] constructor
<vm> [ Machine ] Initializing heap
<vm> [ Machine ] Main memory detected as 129998656 b
<vm> [ Machine ] Reserving 1048576 b for machine use
<vm> [ Field Medic ] ⛑️  Machine allocator for x86 PC functional
<vm> [ Field Medic ] ⛑️  Elf header intact, global constructors functional
<vm> [ Field Medic ] ⛑️  Malloc and brk are functional
<vm> ================================================================================
<vm> 
<vm>                            #include<os> // Literally
<vm> 
<vm> ================================================================================
<vm>      [ Kernel ] Stack: 0x1ffbb8
<vm>      [ Kernel ] Boot magic: 0x2badb002, addr: 0x9500
...
...
<vm>      [ Kernel ] Running service constructors
<vm> --------------------------------------------------------------------------------
<vm> ================================================================================
<vm>  IncludeOS VERY_DIRTY (x86_64 / 64-bit)
<vm>  +--> Running [ OS initialization test ]
<vm> ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<vm>  +--> WARNING: No good random source found: RDRAND/RDSEED instructions not available.
<vm>  +-->        To make this warning fatal, re-compile with FOR_PRODUCTION=ON.
<vm> ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<vm> Service::start entered
<vm> [ Field Medic ] ⛑️  Service finished. Diagnosing.
<vm>                 [+] Field medic plugin active
<vm>                 [+] Post .bss invariant still holds
<vm>                 [+] Post machine init invariant still holds
<vm>                 [+] Post init libc invariant still holds
<vm> [ Field Medic ] ⛑️  Diagnose complete. Healthy ✅

[ SUCCESS ] OS initialization test succeeded
```
