### PR TITLE
Make it easier to write nix files that depend on IncludeOS

### DIFF
--- a/chainloader.nix
+++ b/chainloader.nix
@@ -34,8 +34,8 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "./src/chainload/";
 
-  cmakeFlags = [
-    "-DINCLUDEOS_PACKAGE=${includeos}"
+  buildInputs = [
+    includeos
   ];
 
   srcs = [

--- a/overlay.nix
+++ b/overlay.nix
@@ -159,8 +159,17 @@ final: prev: {
 
       cmakeFlags = archFlags ++ smpFlags;
 
-      # Add some pasthroughs, for easily building the depdencies (for debugging):
+      # Add some pasthroughs, for easily building the dependencies (for debugging):
       # $ nix-build -A NAME
+
+      passthru.vmrunner = prev.callPackage (builtins.fetchGit {
+          url = "https://github.com/includeos/vmrunner";
+        }) {};
+      passthru.chainloader = import ./chainloader.nix { inherit withCcache; };
+      passthru.lest = self.callPackage ./deps/lest {};
+      passthru.pkgsStatic = prev.pkgsStatic; # this is for convenience for other packages that depend on includeos
+      passthru.pkgs = prev.pkgs; # this is for convenience for other packages that depend on includeos
+
       passthru = {
         inherit (self) uzlib;
         inherit (self) http-parser;

--- a/src/chainload/CMakeLists.txt
+++ b/src/chainload/CMakeLists.txt
@@ -1,13 +1,15 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.6)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # IncludeOS install location
 project(chainloader C CXX)
+
+find_package(IncludeOS REQUIRED)
 
 set(ARCH i686)
 set(PLATFORM nano)
 set(ELF_SYMBOLS true)
 
-include(${INCLUDEOS_PACKAGE}/cmake/os.cmake)
+include(os)
 
 option(default_stdout "" ON)
 set(SOURCES


### PR DESCRIPTION
(This PR depends on https://github.com/includeos/vmrunner/pull/37, which removes the requirement for `INCLUDEOS_VMRUNNER` and `INCLUDEOS_CHAINLOADER` from vmrunner.)

- Add vmrunner and chainloader to overlay passthru so they can be easily picked up by other packages
- Add pkgs and pkgsStatic to overlay so other packages don't have to import nixpkgs/overlay unless they have to
- Simplify shell.nix to use the new values from the overlay and remove unused environment variables
- Simplify example.nix and add a test phase to boot the VM

An IncludeOS service can now be built with a very minimal nix derivation (see updated example.nix).

bonus:
- update chainloader to use find_package


