### PR TITLE
Update to nixpkgs 25.05

### DIFF
--- a/deps/botan/default.nix
+++ b/deps/botan/default.nix
@@ -10,12 +10,6 @@ pkgs.botan2.overrideAttrs (oldAttrs: {
     ln -sr "$out/include/botan-2/botan" "$out/include"
   '';
 
-  configurePhase = ''
-    runHook preConfigure
-    python3 configure.py --prefix=$out --with-bzip2 --with-zlib --build-targets=static --cpu=${cpuFlag} --os=linux
-    runHook postConfigure
-  '';
-
   buildPhase = ''
     runHook preBuild
 

--- a/pinned.nix
+++ b/pinned.nix
@@ -1,6 +1,6 @@
 import (
   builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05.tar.gz";
-    sha256 = "1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
+    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/25.05.tar.gz";
+    sha256 = "1r4fhp3apf1qggsrm60ni820gxzpm04q9xdk1w3dap9qymi6bpdk";
   }
 )


### PR DESCRIPTION
- Move pin to nixpkgs 25.05
- Botan 2 now builds without overriding the configurePhase (and fails with the previous override)
- Depends on https://github.com/includeos/vmrunner/pull/39

./test.sh tests succeed, except network tests (due to missing tap device on this host)
