### PR TITLE
update pinned hash of nixpkgs 25.04

### DIFF
--- a/pinned.nix
+++ b/pinned.nix
@@ -1,6 +1,6 @@
 import (
   builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/25.05.tar.gz";
-    sha256 = "1r4fhp3apf1qggsrm60ni820gxzpm04q9xdk1w3dap9qymi6bpdk";
+    sha256 = "1915r28xc4znrh2vf4rrjnxldw2imysz819gzhk9qlrkqanmfsxd";
   }
 )


### PR DESCRIPTION
It seems like the pinned hash for \<nixpkgs> is wrong? I'm unable to build on any machine without this change.

I have verified the sha256sum of both the tar.gz file (`130b4257b3d53bfbfea6d61fb76d4751a3989a4a09a28615ff77516a82b3924d`) and the nix derivation (`1915r28xc4znrh2vf4rrjnxldw2imysz819gzhk9qlrkqanmfsxd`) matches on three separate networks and machines.