### PR TITLE
fix warning: remove redefinition of PAGE_SIZE

### DIFF
--- a/api/virtio/virtio.hpp
+++ b/api/virtio/virtio.hpp
@@ -34,10 +34,13 @@
 
 #include "../hw/pci_device.hpp"
 #include <net/inet_common.hpp>
+#include <limits.h>
 #include <stdint.h>
 #include <vector>
 
-#define PAGE_SIZE 4096
+#if ! defined(PAGE_SIZE)
+#error "PAGE_SIZE not defined. Expected it to be defined by musl's limits.h"
+#endif
 
 #define VIRTIO_F_NOTIFY_ON_EMPTY 24
 #define VIRTIO_F_ANY_LAYOUT 27


### PR DESCRIPTION
musl's `include/limit.h` introduced the page size definition in commit 8e1381be4 (7 years ago). We shouldn't need to redefine it. 

@alfreb I assume there is no semantic difference between virtio's page size (as introduced in 50ab3218) and our local memory's page size. If my assumption here is wrong, please correct me.