### PR TITLE
gitignore clangd files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ CMakeFiles*
 CMakeCache*
 cmake_install.cmake
 
+# clangd related
+.cache/
+compile_commands.json
+
 # Name of installation folder
 IncludeOS_install
 


### PR DESCRIPTION
Since we introduced `compile_commands.json` in `develop.nix` I think it's sensible to assume the user is using clangd for their LSP.