### PR TITLE
Refactor testscript to facilitate running subsets of tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -5,9 +5,11 @@
 # A lot of these tests require vmrunner and a network bridge.
 # See https://github.com/includeos/vmrunner/pull/31
 
-: "${QUICK_SMOKE:=false}"  # Set to "true" for a ~1–5 min smoke test.
-: "${DRY_RUN:=false}"      # Set to "true" to print steps without running them.
-: "${USE_CCACHE:=false}"   # Set to "true" to enable ccache.
+: "${QUICK_SMOKE:=false}"         # Set to "true" for a ~1–5 min smoke test.
+: "${DRY_RUN:=false}"             # Set to "true" to print steps without running them.
+: "${USE_CCACHE:=false}"          # Set to "true" to enable ccache.
+: "${TESTS_STDOUT:=/dev/stdout}"  # Set to /dev/null (or a file) to silence stdout of tests
+: "${TESTS_STDERR:=/dev/stderr}"  # Set to /dev/null (or a file) to silence stderr of tests
 
 steps=0
 fails=0
@@ -65,7 +67,7 @@ run() {
   fi
 
   echo "-------------------------------------- 🗲 --------------------------------------"
-  "${@}"
+  "${@}" >"${TESTS_STDOUT}" 2>"${TESTS_STDERR}"
   errno=$?
   echo "-------------------------------------- 󱦟 --------------------------------------"
 

--- a/test.sh
+++ b/test.sh
@@ -230,7 +230,41 @@ run_all() {
 
 }
 
-run_all
+list_targets(){
+  cat <<EOF
+Available targets:
+  unittests        build_chainloader     build_example
+  multicore_subset smoke_tests           kernel_tests
+  stl_tests        net_tests             all
+EOF
+}
+
+main() {
+  if [ $# -eq 0 ]; then
+    run_all
+  else
+    for t in "$@"; do
+      case "$t" in
+        unittests|build_chainloader|build_example|multicore_subset|smoke_tests|kernel_tests|stl_tests|net_tests)
+          run "$t" "Run target: $t"
+          ;;
+        all)
+          run_all
+          ;;
+        list|-l|--list)
+          list_targets
+          ;;
+        help|-h|--help)
+          echo "Usage: $0 [target ...]"; list_targets
+          ;;
+        *)
+          echo "Unknown target: $t"; list_targets; exit 2
+          ;;
+      esac
+    done
+  fi
+}
+main "$@"
 
 echo -e "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 

--- a/test.sh
+++ b/test.sh
@@ -209,6 +209,17 @@ net_tests() {
   run_testsuite "./test/net/integration" "${exclusions[@]}"
 }
 
+custom_tests() {
+  # write your custom tests here
+  local exclusions=()
+
+  # for testing all subdirectories in path
+  : run_testsuite "./test/path/to/custom/tests*" "${exclusions[@]}"
+
+  # for testing a single test
+  : run_test "./test/path/to/single_test*"
+}
+
 
 run_all() {
   run unittests "Build and run unit tests"
@@ -250,7 +261,7 @@ list_targets(){
 Available targets:
   unittests        build_chainloader     build_example
   multicore_subset smoke_tests           kernel_tests
-  stl_tests        net_tests             all
+  stl_tests        net_tests             custom_tests
 EOF
 }
 
@@ -260,7 +271,7 @@ main() {
   else
     for t in "$@"; do
       case "$t" in
-        unittests|build_chainloader|build_example|multicore_subset|smoke_tests|kernel_tests|stl_tests|net_tests)
+        unittests|build_chainloader|build_example|multicore_subset|smoke_tests|kernel_tests|stl_tests|net_tests|custom_tests)
           run "$t" "Run target: $t"
           ;;
         all)

--- a/test.sh
+++ b/test.sh
@@ -5,9 +5,9 @@
 # A lot of these tests require vmrunner and a network bridge.
 # See https://github.com/includeos/vmrunner/pull/31
 
-: "${QUICK_SMOKE:=}" # Define this to only do a ~1-5 min. smoke test.
-: "${DRY_RUN:=}"     # Define this to expand all steps without running any
-: "${CCACHE_FLAG:=}" # Define as "--arg withCcache true" to enable ccache.
+: "${QUICK_SMOKE:=false}"  # Set to "true" for a ~1–5 min smoke test.
+: "${DRY_RUN:=false}"      # Set to "true" to print steps without running them.
+: "${USE_CCACHE:=false}"   # Set to "true" to enable ccache.
 
 steps=0
 fails=0
@@ -44,7 +44,7 @@ run() {
   echo "-------------------------------------- 💣 --------------------------------------"
 
 
-  if [ ! "$DRY_RUN" ]
+  if [ "$DRY_RUN" != true ]
   then
     $1
   fi
@@ -64,27 +64,27 @@ unittests() {
 }
 
 build_chainloader() {
-  nix-build "${CCACHE_FLAG[@]}" chainloader.nix
+  nix-build --arg withCcache "${USE_CCACHE}" chainloader.nix
 }
 
 build_example() {
-  nix-build "${CCACHE_FLAG[@]}" example.nix
+  nix-build --arg withCcache "${USE_CCACHE}" example.nix
 }
 
 multicore_subset() {
-  nix-shell --pure --arg smp true "${CCACHE_FLAG[@]}" --argstr unikernel ./test/kernel/integration/smp --run ./test.py
+  nix-shell --pure --arg smp true --arg withCcache "${USE_CCACHE}" --argstr unikernel ./test/kernel/integration/smp --run ./test.py
 
   # The following tests are not using multiple CPU's, but have been equippedd with some anyway
   # to make sure core functionality is not broken by missing locks etc. when waking up more cores.
-  nix-shell --pure --arg smp true "${CCACHE_FLAG[@]}" --argstr unikernel ./test/net/integration/udp --run ./test.py
-  nix-shell --pure --arg smp true "${CCACHE_FLAG[@]}" --argstr unikernel ./test/kernel/integration/paging --run ./test.py
+  nix-shell --pure --arg smp true --arg withCcache "${USE_CCACHE}" --argstr unikernel ./test/net/integration/udp --run ./test.py
+  nix-shell --pure --arg smp true --arg withCcache "${USE_CCACHE}" --argstr unikernel ./test/kernel/integration/paging --run ./test.py
 }
 
 smoke_tests() {
-  nix-shell --pure "${CCACHE_FLAG[@]}" --argstr unikernel ./test/net/integration/udp --run ./test.py
-  nix-shell --pure "${CCACHE_FLAG[@]}" --argstr unikernel ./test/net/integration/tcp --run ./test.py
-  nix-shell --pure "${CCACHE_FLAG[@]}" --argstr unikernel ./test/kernel/integration/paging --run ./test.py
-  nix-shell --pure "${CCACHE_FLAG[@]}" --argstr unikernel ./test/kernel/integration/smp --run ./test.py
+  nix-shell --pure --arg withCcache "${USE_CCACHE}" --argstr unikernel ./test/net/integration/udp --run ./test.py
+  nix-shell --pure --arg withCcache "${USE_CCACHE}" --argstr unikernel ./test/net/integration/tcp --run ./test.py
+  nix-shell --pure --arg withCcache "${USE_CCACHE}" --argstr unikernel ./test/kernel/integration/paging --run ./test.py
+  nix-shell --pure --arg withCcache "${USE_CCACHE}" --argstr unikernel ./test/kernel/integration/smp --run ./test.py
 }
 
 run unittests "Build and run unit tests"
@@ -152,7 +152,7 @@ run_testsuite() {
 
 
     # The command to run, as string to be able to print the fully expanded command
-    cmd="nix-shell --pure $CCACHE_FLAG --argstr unikernel $subfolder --run ./test.py"
+    cmd="nix-shell --pure --arg withCcache ${USE_CCACHE} --argstr unikernel $subfolder --run ./test.py"
 
     echo ""
     echo "🚧 Step $steps.$substeps"

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run all known IncludeOS tests.
 #


### PR DESCRIPTION
This PR refactors the `./test.sh` script with three major goals:
- clean up the output
- allow running specific targets manually as `./test.sh net_tests`
- make the script more maintainable

Furthermore there's additionally an option to silence the output of the inner tests through the `TESTS_STDOUT` and `TESTS_STDERR` variables. I find `TESTS_STDOUT=/dev/null ./test.sh` particularly useful.

See `./test.sh help` for a list of targets. Running `./test.sh` with no arguments (or `./test.sh all`) runs the same tests it always did.

There's also a `custom_tests` mock function which just aims to make quick iteration easier.