### PR TITLE
suppress verbose --target mismatch warning

### DIFF
--- a/chainloader.nix
+++ b/chainloader.nix
@@ -6,6 +6,7 @@
     (import ./overlay.nix {
       inherit withCcache;
       smp = false; # No SMP for chainloader
+      disableTargetWarning = true;
     })
   ],
   pkgs ? import nixpkgs {
@@ -47,5 +48,5 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgs.buildPackages.cmake
     pkgs.buildPackages.nasm
-  ];
+  ] ++ [ pkgs.pkgsIncludeOS.suppressTargetWarningHook ];
 }

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
   smp ? false, # Enable multcore support (SMP)
   nixpkgs ? ./pinned.nix,
   overlays ? [
-    (import ./overlay.nix { inherit withCcache; inherit smp; } )
+    (import ./overlay.nix { inherit withCcache; inherit smp; disableTargetWarning = true; } )
   ],
   pkgs ? import nixpkgs { config = {}; inherit overlays; }
 }:

--- a/unikernel.nix
+++ b/unikernel.nix
@@ -49,7 +49,7 @@ includeos.stdenv.mkDerivation rec {
   nativeBuildInputs = [
     includeos.pkgs.buildPackages.nasm
     includeos.pkgs.buildPackages.cmake
-  ];
+  ] ++ [ includeos.pkgs.pkgsIncludeOS.suppressTargetWarningHook ];
 
   buildInputs = [
     includeos


### PR DESCRIPTION
`nixpkgs/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh` has a flag to suppress the rather annoying (albeit correct) warning:

```
Warning: supplying the --target x86_64-pc-linux-elf != x86_64-unknown-linux-musl argument to a nix-wrapped compiler may not work correctly - cc-wrapper is currently not designed with multi-target compilers in mind. You may want to use an un-wrapped compiler instead.
```

This adds an option (enabled by default across the board) to suppress this. Because of how `example/` is built, I had to implement it two places (ideally I'd inherit it in `example.nix`, which is only used as a test currently... maybe we should change that).