### PR TITLE
bump llvmPackages from 18 to 19

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -5,7 +5,7 @@
 final: prev: {
 
   stdenvIncludeOS = prev.pkgsStatic.lib.makeScope prev.pkgsStatic.newScope (self: {
-    llvmPkgs = prev.pkgsStatic.llvmPackages_18;
+    llvmPkgs = prev.pkgsStatic.llvmPackages_19;
     stdenv = self.llvmPkgs.libcxxStdenv; # Use this as base stdenv
 
     # Import unpatched musl for building libcxx. Libcxx needs some linux headers to be passed through.

--- a/unittests.nix
+++ b/unittests.nix
@@ -1,6 +1,6 @@
 { nixpkgs ? ./pinned.nix,
   pkgs ? import nixpkgs { config = { }; overlays = [ ]; },
-  stdenv ? pkgs.llvmPackages_18.libcxxStdenv,
+  stdenv ? pkgs.llvmPackages_19.libcxxStdenv,
   withCcache ? false,
 }:
 stdenv.mkDerivation rec {


### PR DESCRIPTION
Related to #2307, this bumps to llvm19 without any issue. There are warnings about `-pie` and `-rtlib=` being unused when building llvmPkgs: I suspect this has always been the case.

Tested both with and without #2317.