### PR TITLE
use proper zone-id for slaac test

### DIFF
--- a/test/net/integration/slaac/test.py
+++ b/test/net/integration/slaac/test.py
@@ -26,7 +26,7 @@ def Slaac_test(trigger_line):
   print(color.INFO("<Test.py>"), "Trying to ping")
   time.sleep(1)
   try:
-    command = ["ping", "-I", "bridge43", ip_string.rstrip(), "-c",
+    command = ["ping", ip_string.rstrip() + "%bridge43", "-c",
             str(ping_count) ]
     print(color.DATA(" ".join(command)))
     print(subprocess.check_output(command))


### PR DESCRIPTION
`./test/net/integration/slaac/` gives the following warning:

```
ping -I bridge43 fe80:0:0:0:c201:aff:fe00:2a -c 3

ping: Warning: IPv6 link-local address on ICMP datagram socket may require ifname or scope-id => use: address%<ifname|scope-id>
ping: Warning: source address might be selected on device other than: bridge43
```

IPv6 has syntax for specifying in which zone a request is valid, see https://datatracker.ietf.org/doc/html/rfc4007#section-11 for details.

We can also drop `-I bridge43` after adding the zone id specifier. It could be meaningful to specify the outgoing interface if we had different routes with the same zone id, but this isn't the case for us.

The test still runs and succeeds with this change.
