### PR TITLE
Introduce enum-class for memory flags

### DIFF
--- a/api/arch/x86/paging.hpp
+++ b/api/arch/x86/paging.hpp
@@ -127,11 +127,11 @@ namespace paging {
 using namespace util::literals;
 using namespace util::bitops;
 
-/** Conversion from x86 paging flags to mem::Accessflags **/
-os::mem::Access to_memflags(Flags f);
+/** Conversion from x86 paging flags to mem::Permission flags **/
+os::mem::Permission to_memflags(Flags f);
 
-/** Conversion from mem::Access flags to x86 paging flags **/
-Flags to_x86(os::mem::Access prot);
+/** Conversion from mem::Permission flags to x86 paging flags **/
+Flags to_x86(os::mem::Permission prot);
 
 /** Summary of currently mapped page- and page directories **/
 struct Summary {

--- a/api/arch/x86/paging_utils.hpp
+++ b/api/arch/x86/paging_utils.hpp
@@ -19,6 +19,7 @@
 #ifndef X86_PAGING_UTILS
 #define X86_PAGING_UTILS
 
+#include "arch/x86/paging.hpp"
 #include <iostream>
 #include <map>
 

--- a/api/sys/mman.hpp
+++ b/api/sys/mman.hpp
@@ -1,0 +1,30 @@
+/*
+ * provides namespaced types for `sys_mman(0p)` values
+ */
+#ifndef	_SYS_MMAN_HPP
+#define	_SYS_MMAN_HPP
+
+#include <cstdint>
+#include <sys/mman.h>
+#include <util/bitops.hpp>
+#include <type_traits>
+
+namespace os::mem {
+  enum class Flags : uint8_t {
+    None      = 0,
+    Shared    = MAP_SHARED,
+    Private   = MAP_PRIVATE,
+    Fixed     = MAP_FIXED,
+    Anonymous = MAP_ANONYMOUS,
+  };
+} // os::mmap
+
+
+namespace util {
+  inline namespace bitops {
+    template<> struct enable_bitmask_ops<os::mem::Flags> {
+      using type = std::underlying_type<os::mem::Flags>::type;
+      static constexpr bool enable = true;
+    };
+  }
+

--- a/api/sys/mman.hpp
+++ b/api/sys/mman.hpp
@@ -17,6 +17,20 @@ namespace os::mem {
     Fixed     = MAP_FIXED,
     Anonymous = MAP_ANONYMOUS,
   };
+
+  enum class Permission : uint8_t {  // TODO(mazunki): consider making Permission::{Read,Write,Execute} private or standalone class
+    Read    = PROT_READ,
+    Write   = PROT_WRITE,
+    Execute = PROT_EXEC,
+
+    Data    = Read | Write,
+    Code    = Read | Execute,
+
+    Any     = 0,  // TODO(mazunki): this should really be R|W|X; but requires some refactoring
+    RWX     = Read|Write|Execute,  // TODO(mazunki): temporary, remove me. references should use Permission::Any
+
+    // None    = 0,  // TODO(mazunki): implement this after Any is properly implemented (to avoid confusion with old Access::none which had a different meaning). should block all access (best used for unmapped stuff, potentially tests)
+  };
 } // os::mmap
 
 
@@ -28,3 +42,12 @@ namespace util {
     };
   }
 
+  inline namespace bitops {
+    template<>
+    struct enable_bitmask_ops<os::mem::Permission> {
+      using type = typename std::underlying_type<os::mem::Permission>::type;
+      static constexpr bool enable = true;
+    };
+  }
+}
+#endif // _SYS_MMAN_HPP

--- a/api/util/bitops.hpp
+++ b/api/util/bitops.hpp
@@ -115,7 +115,7 @@ constexpr operator~(E flag){
 
 // bool has_flag(flag)
 template<typename E>
-constexpr typename std::enable_if<enable_bitmask_ops<E>::enable, bool>::type
+[[nodiscard]] constexpr typename std::enable_if<enable_bitmask_ops<E>::enable, bool>::type
 has_flag(E flag){
   using base_type = typename std::underlying_type<E>::type;
   return static_cast<base_type>(flag);
@@ -123,9 +123,24 @@ has_flag(E flag){
 
 // bool has_flag(field, flags)
 template<typename E>
-constexpr typename std::enable_if<enable_bitmask_ops<E>::enable, bool>::type
+[[nodiscard]] constexpr typename std::enable_if<enable_bitmask_ops<E>::enable, bool>::type
 has_flag(E field, E flags){
   return (field & flags) == flags ;
+}
+
+// bool missing_flag(flag)
+template<typename E>
+[[nodiscard]] constexpr typename std::enable_if<enable_bitmask_ops<E>::enable, bool>::type
+missing_flag(E flag){
+  using base_type = typename std::underlying_type<E>::type;
+  return static_cast<base_type>(flag) == 0;
+}
+
+// bool missing_flag(field, flags)
+template<typename E>
+[[nodiscard]] constexpr typename std::enable_if<enable_bitmask_ops<E>::enable, bool>::type
+missing_flag(E field, E flags) noexcept {
+  return (field & flags) != flags;
 }
 
 

--- a/deps/musl/default.nix
+++ b/deps/musl/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./patches/musl.patch
     ./patches/endian.patch
+    ./patches/mmap.patch
   ];
 
   passthru.linuxHeaders = linuxHeaders;

--- a/deps/musl/patches/mmap.patch
+++ b/deps/musl/patches/mmap.patch
@@ -1,0 +1,21 @@
+diff --git a/src/mman/mmap.c b/src/mman/mmap.c
+index 43e5e029..43307692 100644
+--- a/src/mman/mmap.c
++++ b/src/mman/mmap.c
+@@ -36,4 +36,15 @@ void *__mmap(void *start, size_t len, int prot, int flags, int fd, off_t off)
+ 	return (void *)__syscall_ret(ret);
+ }
+ 
+-weak_alias(__mmap, mmap);
++void *__includeos_mmap(void *start, size_t len, int prot, int flags, int fd, off_t off)
++{
++	long ret;
++	if (flags & MAP_FIXED) {
++		__vm_wait();
++	}
++	ret = __syscall(SYS_mmap, start, len, prot, flags, fd, off);
++
++	return (void *) ret;
++}
++
++weak_alias(__includeos_mmap, mmap);

--- a/src/arch/i686/paging.cpp
+++ b/src/arch/i686/paging.cpp
@@ -33,6 +33,6 @@ namespace mem {
   }
 
   template <>
-  const size_t Mapping<os::mem::Access>::any_size = 4096;
+  const size_t Mapping<os::mem::Permission>::any_size = 4096;
 }
 }

--- a/src/arch/x86_64/ist.cpp
+++ b/src/arch/x86_64/ist.cpp
@@ -38,7 +38,7 @@ static stack create_stack_virt(size_t size, const char* name)
   // TODO randomize location / ask virtual memory allocator
   const uintptr_t stack_area = 1ull << 46;
 
-  const mem::Access flags = mem::Access::read | mem::Access::write;
+  const mem::Permission flags = mem::Permission::Data;
 
   // Virtual area
   // Adds a guard page between each new stack
@@ -53,7 +53,7 @@ static stack create_stack_virt(size_t size, const char* name)
 
   Expects(map);
   Expects(mem::active_page_size(map.lin) == 4096);
-  Expects(mem::flags(map.lin - 1) == mem::Access::none
+  Expects(mem::flags(map.lin - 1) == mem::Permission::Any // TODO(mazunki): should this be Permission::None?
           && "Guard page should not present");
 
   // Next stack starts after next page

--- a/src/kernel/elf.cpp
+++ b/src/kernel/elf.cpp
@@ -502,6 +502,6 @@ void elf_protect_symbol_areas()
       {(uintptr_t) src, (uintptr_t) src + size-1, "Symbols & strings"});
 
   INFO2("* Protecting syms %p to %p (size %#zx)", src, &src[size], size);
-  os::mem::protect((uintptr_t) src, size, os::mem::Access::read);
+  os::mem::protect((uintptr_t) src, size, os::mem::Permission::Read);
 }
 #endif

--- a/src/kernel/multiboot.cpp
+++ b/src/kernel/multiboot.cpp
@@ -164,7 +164,7 @@ void kernel::multiboot(uint32_t boot_addr)
       if (not (map.type & MULTIBOOT_MEMORY_AVAILABLE)) {
 
         if (util::bits::is_aligned<4_KiB>(map.addr)) {
-          os::mem::map({addr, addr, os::mem::Access::read | os::mem::Access::write, size},
+          os::mem::map({addr, addr, os::mem::Permission::Data, size},
                        "Reserved (Multiboot)");
           continue;
         }
@@ -175,7 +175,7 @@ void kernel::multiboot(uint32_t boot_addr)
       else
       {
         // Map as free memory
-        //os::mem::map_avail({map.addr, map.addr, {os::mem::Access::read | os::mem::Access::write}, map.len}, "Reserved (Multiboot)");
+        //os::mem::map_avail({map.addr, map.addr, {os::mem::Permission::Data}, map.len}, "Reserved (Multiboot)");
       }
     }
     INFO2("");

--- a/src/musl/mmap.cpp
+++ b/src/musl/mmap.cpp
@@ -57,7 +57,7 @@ uintptr_t mmap_allocation_end() {
 static void* sys_mmap(void * addr, size_t length, int /*prot*/, int _flags,
                       int fd, off_t /*offset*/)
 {
-  using os::mmap::Flags;
+  using os::mem::Flags;
   const Flags flags = static_cast<Flags>(_flags);
 
   // TODO: Implement minimal functionality to be POSIX compliant

--- a/src/platform/x86_pc/os.cpp
+++ b/src/platform/x86_pc/os.cpp
@@ -139,7 +139,7 @@ void kernel::start(uint32_t boot_magic, uint32_t boot_addr)
 #if defined(ARCH_x86_64)
   // protect the basic pagetable used by LiveUpdate and any other
   // systems that need to exit long/protected mode
-  os::mem::map({0x1000, 0x1000, os::mem::Access::read, 0x7000}, "Page tables");
+  os::mem::map({0x1000, 0x1000, os::mem::Permission::Read, 0x7000}, "Page tables");
   memmap.assign_range({0x10000, 0x9d3ff, "Stack"});
 #elif defined(ARCH_i686)
   memmap.assign_range({0x10000, 0x9d3ff, "Stack"});

--- a/test/kernel/integration/memmap/service.cpp
+++ b/test/kernel/integration/memmap/service.cpp
@@ -52,7 +52,7 @@ void Service::start(const std::string&)
 
   // mem::map is using memory_map to keep track of virutal memory
   // TODO: we might consider consolidating ranges with mappings.
-  auto m = os::mem::map({42_GiB, 42_GiB, os::mem::Access::read, 1_GiB},
+  auto m = os::mem::map({42_GiB, 42_GiB, os::mem::Permission::Read, 1_GiB},
                         "Test range");
   Expects(m);
   Expects(map.size() == s + 1);

--- a/test/kernel/unit/x86_paging.cpp
+++ b/test/kernel/unit/x86_paging.cpp
@@ -346,20 +346,20 @@ void init_default_paging(uintptr_t exec_beg = 0xa00000, uintptr_t exec_end = 0xb
 CASE ("x86::paging Verify execute protection")
 {
     using namespace util;
-    using Access = os::mem::Access;
+    using Permission = os::mem::Permission;
 
     init_default_paging(0xa00000, 0xc00000);
     // 4KiB 0-page has no access
     EXPECT(__pml4->active_page_size(0LU) == 4_KiB);
     EXPECT(os::mem::active_page_size(0LU) == 4_KiB);
-    EXPECT(os::mem::flags(0) == Access::none);
+    EXPECT(os::mem::flags(0) == Permission::Any);
 
     auto flags = os::mem::flags(__exec_begin);
 
     // .text segment has execute + read access up to next 4kb page
-    EXPECT(os::mem::flags(__exec_begin) == (Access::execute | Access::read));
-    EXPECT(os::mem::flags(__exec_end - 1)   == (Access::execute | Access::read));
-    EXPECT(os::mem::flags(__exec_end + 4_KiB) == (Access::read | Access::write));
+    EXPECT(os::mem::flags(__exec_begin) == Permission::Code);
+    EXPECT(os::mem::flags(__exec_end - 1)   == Permission::Code);
+    EXPECT(os::mem::flags(__exec_end + 4_KiB) == Permission::Data);
 
     for (int i = 0; i < 10; i++ ) {
       auto exec_start = (rand() & ~0xfff);
@@ -369,13 +369,13 @@ CASE ("x86::paging Verify execute protection")
 
       // 4KiB 0-page has no access
       EXPECT(os::mem::active_page_size(0LU) == 4_KiB);
-      EXPECT(os::mem::flags(0) == Access::none);
+      EXPECT(os::mem::flags(0) == Permission::Any);
 
       // .text segment has execute + read access up to next 4kb page
-      EXPECT(os::mem::flags(__exec_begin) == (Access::execute | Access::read));
+      EXPECT(os::mem::flags(__exec_begin) == Permission::Code);
 
-      EXPECT(os::mem::flags(__exec_end - 1)   == (Access::execute | Access::read));
-      EXPECT(os::mem::flags(__exec_end + 4_KiB) == (Access::read | Access::write));
+      EXPECT(os::mem::flags(__exec_end - 1)   == Permission::Code);
+      EXPECT(os::mem::flags(__exec_end + 4_KiB) == Permission::Data);
     }
 }
 
@@ -447,7 +447,7 @@ CASE ("x86::paging Verify default paging setup")
     using namespace util;
 
     using Flags = x86::paging::Flags;
-    using Access = os::mem::Access;
+    using Permission = os::mem::Permission;
 
     init_default_paging();
 
@@ -455,31 +455,31 @@ CASE ("x86::paging Verify default paging setup")
     {
       // 4KiB 0-page has no access
       EXPECT(os::mem::active_page_size(0LU) == 4_KiB);
-      EXPECT(os::mem::flags(0) == Access::none);
+      EXPECT(os::mem::flags(0) == Permission::Any);
 
       // .text segment has execute + read access up to next 4kb page
       EXPECT(os::mem::active_page_size(__exec_begin) == 4_KiB);
-      EXPECT(os::mem::flags(__exec_begin) == (Access::execute | Access::read));
-      EXPECT(os::mem::flags(__exec_end)   == (Access::execute | Access::read));
-      EXPECT(os::mem::flags(__exec_end + 4_KiB) == (Access::read | Access::write));
+      EXPECT(os::mem::flags(__exec_begin) == Permission::Code);
+      EXPECT(os::mem::flags(__exec_end)   == Permission::Code);
+      EXPECT(os::mem::flags(__exec_end + 4_KiB) == Permission::Data);
 
       // Remaining address space is either read + write or not present
-      EXPECT(os::mem::flags(100_MiB)  == (Access::read | Access::write));
-      EXPECT(os::mem::flags(1_GiB)    == (Access::read | Access::write));
-      EXPECT(os::mem::flags(2_GiB)    == (Access::read | Access::write));
-      EXPECT(os::mem::flags(4_GiB)    == (Access::read | Access::write));
-      EXPECT(os::mem::flags(8_GiB)    == (Access::read | Access::write));
-      EXPECT(os::mem::flags(16_GiB)   == (Access::read | Access::write));
-      EXPECT(os::mem::flags(32_GiB)   == (Access::read | Access::write));
-      EXPECT(os::mem::flags(64_GiB)   == (Access::read | Access::write));
-      EXPECT(os::mem::flags(128_GiB)  == (Access::read | Access::write));
-      EXPECT(os::mem::flags(256_GiB)  == (Access::read | Access::write));
-      EXPECT(os::mem::flags(512_GiB)  == (Access::none));
-      EXPECT(os::mem::flags(1_TiB)    == (Access::none));
-      EXPECT(os::mem::flags(128_TiB)  == (Access::none));
-      EXPECT(os::mem::flags(256_TiB)  == (Access::none));
-      EXPECT(os::mem::flags(512_TiB)  == (Access::none));
-      EXPECT(os::mem::flags(1024_TiB) == (Access::none));
+      EXPECT(os::mem::flags(100_MiB)  == Permission::Data);
+      EXPECT(os::mem::flags(1_GiB)    == Permission::Data);
+      EXPECT(os::mem::flags(2_GiB)    == Permission::Data);
+      EXPECT(os::mem::flags(4_GiB)    == Permission::Data);
+      EXPECT(os::mem::flags(8_GiB)    == Permission::Data);
+      EXPECT(os::mem::flags(16_GiB)   == Permission::Data);
+      EXPECT(os::mem::flags(32_GiB)   == Permission::Data);
+      EXPECT(os::mem::flags(64_GiB)   == Permission::Data);
+      EXPECT(os::mem::flags(128_GiB)  == Permission::Data);
+      EXPECT(os::mem::flags(256_GiB)  == Permission::Data);
+      EXPECT(os::mem::flags(512_GiB)  == Permission::Any);
+      EXPECT(os::mem::flags(1_TiB)    == Permission::Any);
+      EXPECT(os::mem::flags(128_TiB)  == Permission::Any);
+      EXPECT(os::mem::flags(256_TiB)  == Permission::Any);
+      EXPECT(os::mem::flags(512_TiB)  == Permission::Any);
+      EXPECT(os::mem::flags(1024_TiB) == Permission::Any);
 
     }
 


### PR DESCRIPTION
This PR introduces enum-class types for memory flags, and acts as a first step refactor for `os::mem::Permission` (which used to be called Access).

---
Previously, we have been reusing the same "values" from POSIX which correspond to the mprotect() values, which I don't think makes much sense.

In my head, if I read `Access::none`, my intepretation is that all access is denied: which is exactly the opposite of the case. I intend to introduce `Permission::Empty` to signify an unset permission, `Permission::Any` to be equivalent to `Read|Write|Execute`. There's a set of `TODO(mazunki)` objects which I'll handle in a subsequent PR for this unless there's any objections to the idea.

---
I also see there's basically no tests involving `mmap()` (only one I can see is a single unit test: `util/unit/tar_test.cpp`). I will have to introduce more tests in this aspect. @alfreb , you mentioned you built the allocators with a bunch of tests: can you remember if there were any tests beyond the unit tests for `{buddy,fixed_list,pmr}_alloc_test.cpp`? Could be I'm just blind here.

There are a few references to `os::mem::vmmap()`. Other than being related to virtual memory, it's not really super clear what this is supposed to do. It seems to just be a generic memory map of the whole memory space. There are far more tests for this, but far more undocumented.

---
After this is properly merged, I also intend to modify the signature of `sys_mmap()` to only accept enums. Currently, the implementation is really just an internal typecast: it makes refactoring easier. A benefit of using enum-classes is that we can fail at compile-time if wrong values are provided.

I also intend to change the type of the file descriptor to something like an `std::optional<int>` or similar. This is C++, we shouldn't need magic values for this sort of thing.