### PR TITLE
add missing include for x86 memory flags

### DIFF
--- a/api/arch/x86/paging_utils.hpp
+++ b/api/arch/x86/paging_utils.hpp
@@ -19,6 +19,7 @@
 #ifndef X86_PAGING_UTILS
 #define X86_PAGING_UTILS
 
+#include "arch/x86/paging.hpp"
 #include <iostream>
 #include <map>
 


### PR DESCRIPTION
Trivial fix. It was compiling fine and without warning without it, but technically is wrong. LSP will not find the symbol without it.