### PR TITLE
Segregate `kernel/memory.hpp` into meaningful parts

### DIFF
--- a/api/arch/x86/paging.hpp
+++ b/api/arch/x86/paging.hpp
@@ -22,7 +22,7 @@
 #include <delegate>
 #include <util/bitops.hpp>
 #include <util/units.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <cstdlib>
 #include <expects>
 

--- a/api/mem/alloc.hpp
+++ b/api/mem/alloc.hpp
@@ -1,0 +1,28 @@
+#ifndef MEM_ALLOC_HPP
+#define MEM_ALLOC_HPP
+
+#include <mem/alloc/buddy.hpp>
+#include <mem/allocator.hpp>
+
+namespace os::mem {
+
+  using Raw_allocator = buddy::Alloc<false>;
+
+  /** Get default allocator for untyped allocations */
+  Raw_allocator& raw_allocator();
+
+  template <typename T>
+  using Typed_allocator = Allocator<T, Raw_allocator>;
+
+  /** Get default std::allocator for typed allocations */
+  template <typename T>
+  inline Typed_allocator<T> system_allocator() {
+    return Typed_allocator<T>(raw_allocator());
+  }
+
+  /** True once the heap is initialized and usable */
+  bool heap_ready();
+
+} // namespace os::mem
+
+#endif // MEM_ALLOC_HPP

--- a/api/mem/flags.hpp
+++ b/api/mem/flags.hpp
@@ -1,0 +1,26 @@
+#ifndef	MEM_FLAGS_HPP
+#define	MEM_FLAGS_HPP
+
+#include <cstdint>
+#include <util/bitops.hpp>
+
+namespace os::mem {
+  enum class Access : uint8_t {
+      none = 0,
+      read = 1,
+      write = 2,
+      execute = 4
+    };
+} // os::mem
+
+namespace util {
+  inline namespace bitops {
+    template<>
+    struct enable_bitmask_ops<os::mem::Access> {
+      using type = typename std::underlying_type<os::mem::Access>::type;
+      static constexpr bool enable = true;
+    };
+  }
+}
+
+#endif // MEM_FLAGS_HPP

--- a/api/mem/memmap.hpp
+++ b/api/mem/memmap.hpp
@@ -16,8 +16,8 @@
 // limitations under the License.
 
 #pragma once
-#ifndef KERNEL_MEMMAP_HPP
-#define KERNEL_MEMMAP_HPP
+#ifndef MEM_MEMMAP_HPP
+#define MEM_MEMMAP_HPP
 
 #include <cassert>
 #include <delegate>
@@ -466,4 +466,4 @@ private:
 }; //< class Memory_map
 
 } // ns os::mem
-#endif //< KERNEL_MEMMAP_HPP
+#endif //< MEM_MEMMAP_HPP

--- a/api/mem/memory.hpp
+++ b/api/mem/memory.hpp
@@ -23,19 +23,12 @@
 #include <util/units.hpp>
 #include <mem/alloc/buddy.hpp>
 #include <mem/allocator.hpp>
+#include <mem/flags.hpp>
 #include <sstream>
 #include <expects>
 #include <mem/memmap.hpp>
 
 namespace os::mem {
-
-  /** POSIX mprotect compliant access bits **/
-  enum class Access : uint8_t {
-    none = 0,
-    read = 1,
-    write = 2,
-    execute = 4
-  };
 
   using Raw_allocator = buddy::Alloc<false>;
 
@@ -177,17 +170,6 @@ namespace os::mem {
 
 
 
-
-// Enable bitwise ops on access flags
-namespace util {
-inline namespace bitops {
-  template<>
-  struct enable_bitmask_ops<os::mem::Access> {
-    using type = typename std::underlying_type<os::mem::Access>::type;
-    static constexpr bool enable = true;
-  };
-}
-}
 
 
 namespace os::mem {

--- a/api/mem/memory.hpp
+++ b/api/mem/memory.hpp
@@ -16,8 +16,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef KERNEL_MEMORY_HPP
-#define KERNEL_MEMORY_HPP
+#ifndef MEM_MEMORY_HPP
+#define MEM_MEMORY_HPP
 
 #include <util/bitops.hpp>
 #include <util/units.hpp>
@@ -25,7 +25,7 @@
 #include <mem/allocator.hpp>
 #include <sstream>
 #include <expects>
-#include <kernel/memmap.hpp>
+#include <mem/memmap.hpp>
 
 namespace os::mem {
 
@@ -342,4 +342,4 @@ namespace os::mem {
 }
 
 
-#endif
+#endif  // MEM_MEMORY_HPP

--- a/api/mem/vmap.hpp
+++ b/api/mem/vmap.hpp
@@ -1,46 +1,17 @@
-// -*- C++ -*-
-// This file is a part of the IncludeOS unikernel - www.includeos.org
-//
-// Copyright 2017 Oslo and Akershus University College of Applied Sciences
-// and Alfred Bratterud
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-#ifndef MEM_MEMORY_HPP
-#define MEM_MEMORY_HPP
+#ifndef MEM_VMAP_HPP
+#define MEM_VMAP_HPP
 
 #include <util/bitops.hpp>
 #include <util/units.hpp>
-#include <mem/alloc/buddy.hpp>
-#include <mem/allocator.hpp>
 #include <mem/flags.hpp>
-#include <sstream>
-#include <expects>
 #include <mem/memmap.hpp>
+#include <expects>
+#include <algorithm>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
 
 namespace os::mem {
-
-  using Raw_allocator = buddy::Alloc<false>;
-
-  /** Get default allocator for untyped allocations */
-  Raw_allocator& raw_allocator();
-
-  template <typename T>
-  using Typed_allocator = Allocator<T, Raw_allocator>;
-
-  /** Get default std::allocator for typed allocations */
-  template <typename T>
-  Typed_allocator<T> system_allocator() { return Typed_allocator<T>(raw_allocator()); }
 
   /** Get bitfield with bit set for each supported page size */
   uintptr_t supported_page_sizes();
@@ -62,15 +33,14 @@ namespace os::mem {
    * For interfacing with the virtual memory API, e.g. mem::map / mem::protect.
    **/
   template <typename Fl = Access>
-  struct Mapping
-  {
+  struct Mapping {
     static const size_t any_size;
 
     uintptr_t lin  = 0;
     uintptr_t phys = 0;
-    Fl flags {};
-    size_t size = 0;
-    size_t page_sizes = 0;
+    Fl        flags {};
+    size_t    size = 0;
+    size_t    page_sizes = 0;
 
     // Constructors
     Mapping() = default;
@@ -94,15 +64,13 @@ namespace os::mem {
     inline size_t max_psize() const noexcept;
 
     std::string to_string() const;
-
-  }; // struct Mapping<>
+  };
 
   using Map = Mapping<>;
 
   /** Exception class possibly used by various ::mem functions. **/
   class Memory_exception : public std::runtime_error
-  { using runtime_error::runtime_error; };
-
+  { using std::runtime_error::runtime_error; };
 
   /**
    * Map linear address to physical memory, according to provided Mapping.
@@ -123,7 +91,9 @@ namespace os::mem {
 
   /** Determine active page size of a given linear address **/
   uintptr_t active_page_size(uintptr_t addr);
-  uintptr_t active_page_size(void* addr);
+  inline uintptr_t active_page_size(void* addr) {
+    return active_page_size((uintptr_t) addr);
+  }
 
   /**
    * Set and return access flags for a given linear address range.
@@ -150,81 +120,70 @@ namespace os::mem {
    **/
   Access protect_page(uintptr_t linear, Access flags = Access::read);
 
-
   /** Get the physical address to which linear address is mapped **/
   uintptr_t virt_to_phys(uintptr_t linear);
 
-  void virtual_move(uintptr_t src, size_t size, uintptr_t dst, const char* label);
+  inline void virtual_move(uintptr_t src, size_t size, uintptr_t dst, const char* label)
+  {
+    using namespace util::bitops;
+    const auto flags = os::mem::Access::read | os::mem::Access::write;
+    // setup @dst as new virt area for @src
+    os::mem::map({dst, src, flags, size}, label);
+    // unpresent @src
+    os::mem::protect(src, size, os::mem::Access::none);
+  }
 
   /** Virtual memory map **/
   inline Memory_map& vmmap() {
     // TODO Move to machine
     static Memory_map memmap;
     return memmap;
-  };
-
-  bool heap_ready();
-
-} // os::mem
+  }
 
 
-
-
-
-
-namespace os::mem {
 
   //
-  // mem::Mapping implementation
+  // Mapping implementation
   //
+  template <typename Fl>
+  inline Mapping<Fl>::Mapping(uintptr_t linear, uintptr_t physical, Fl fl, size_t sz)
+    : lin{linear}, phys{physical}, flags{fl}, size{sz}, page_sizes{any_size} {}
 
   template <typename Fl>
-  Mapping<Fl>::Mapping(uintptr_t linear, uintptr_t physical, Fl fl, size_t sz)
-      : lin{linear}, phys{physical}, flags{fl}, size{sz},
-        page_sizes{any_size} {}
+  inline Mapping<Fl>::Mapping(uintptr_t linear, uintptr_t physical, Fl fl, size_t sz, size_t psz)
+    : lin{linear}, phys{physical}, flags{fl}, size{sz}, page_sizes{psz} {}
 
   template <typename Fl>
-  Mapping<Fl>::Mapping(uintptr_t linear, uintptr_t physical, Fl fl, size_t sz, size_t psz)
-    : lin{linear}, phys{physical}, flags{fl}, size{sz}, page_sizes{psz}
-    {}
+  inline bool Mapping<Fl>::operator==(const Mapping& rhs) const noexcept {
+    return lin == rhs.lin
+        && phys == rhs.phys
+        && flags == rhs.flags
+        && size == rhs.size
+        && page_sizes == rhs.page_sizes;
+  }
 
   template <typename Fl>
-  bool Mapping<Fl>::operator==(const Mapping& rhs) const noexcept
-  { return lin == rhs.lin
-      && phys == rhs.phys
-      && flags == rhs.flags
-      && size == rhs.size
-      && page_sizes == rhs.page_sizes; }
+  inline Mapping<Fl>::operator bool() const noexcept {
+    return size != 0 && page_sizes != 0;
+  }
 
   template <typename Fl>
-  Mapping<Fl>::operator bool() const noexcept
-  { return size != 0 && page_sizes !=0; }
+  inline bool Mapping<Fl>::operator!=(const Mapping& rhs) const noexcept {
+    return !(*this == rhs);
+  }
 
   template <typename Fl>
-  bool Mapping<Fl>::operator!=(const Mapping& rhs) const noexcept
-  { return ! (*this == rhs); }
-
-  template <typename Fl>
-  Mapping<Fl> Mapping<Fl>::operator+(const Mapping& rhs) noexcept
-  {
+  inline Mapping<Fl> Mapping<Fl>::operator+(const Mapping& rhs) noexcept {
     using namespace util::bitops;
     Mapping res;
 
     // Adding with empty map behaves like 0 + x / x + 0.
-    if (! rhs) {
-      return *this;
-    }
-
-    if (! *this)
-      return rhs;
-
-    if (res == rhs)
-      return res;
+    if (not rhs) return *this;
+    if (not *this) return rhs;
+    if (res == rhs) return res;
 
     // The mappings must have connecting ranges
-    if ((rhs.lin + rhs.size != lin)
-        and lin + size != rhs.lin)
-    {
+    if ((rhs.lin + rhs.size != lin) and (lin + size != rhs.lin)) {
       Ensures(!res);
       return res;
     }
@@ -235,37 +194,35 @@ namespace os::mem {
 
     // The mappings can span several page sizes
     res.page_sizes |= rhs.page_sizes;
-    if (page_sizes && page_sizes != rhs.page_sizes)
-    {
+    if (page_sizes && page_sizes != rhs.page_sizes) {
       res.page_sizes |= page_sizes;
     }
 
-    res.size = size + rhs.size;
+    res.size  = size + rhs.size;
     res.flags = flags & rhs.flags;
 
-    if (rhs)
-      Ensures(res);
-
+    if (rhs) Ensures(res);
     return res;
   }
 
   template <typename Fl>
-  Mapping<Fl> Mapping<Fl>::operator+=(const Mapping& rhs) noexcept {
+  inline Mapping<Fl> Mapping<Fl>::operator+=(const Mapping& rhs) noexcept {
     *this = *this + rhs;
     return *this;
   }
 
   template <typename Fl>
-  size_t Mapping<Fl>::min_psize() const noexcept
-  { return util::bits::keepfirst(page_sizes); }
+  inline size_t Mapping<Fl>::min_psize() const noexcept {
+    return util::bits::keepfirst(page_sizes);
+  }
 
   template <typename Fl>
-  size_t Mapping<Fl>::max_psize() const noexcept
-  { return util::bits::keeplast(page_sizes); }
+  inline size_t Mapping<Fl>::max_psize() const noexcept {
+    return util::bits::keeplast(page_sizes);
+  }
 
   template <typename Fl>
-  inline std::string Mapping<Fl>::to_string() const
-  {
+  inline std::string Mapping<Fl>::to_string() const {
     using namespace util::literals;
     char buffer[1024];
     int len = snprintf(buffer, sizeof(buffer),
@@ -281,47 +238,35 @@ namespace os::mem {
                       " (%lu pages á %s)",
                       size / page_sizes,
                       util::Byte_r(page_sizes).to_string().c_str());
-    }
-    else {
+    } else {
       len += snprintf(buffer + len, sizeof(buffer) - len,
               " (page sizes: %s)", page_sizes_str(page_sizes).c_str());
     }
-
     return std::string(buffer, len);
   }
 
-  inline std::string page_sizes_str(size_t bits)
-  {
+  inline std::string page_sizes_str(size_t bits) {
     using namespace util::literals;
     if (bits == 0) return "None";
 
     std::string out;
-    while (bits){
-      auto ps = 1 << (__builtin_ffsl(bits) - 1);
-      bits &= ~ps;
-      out += util::Byte_r(ps).to_string();
-      if (bits)
-        out += ", ";
-    }
+    while (bits) {
+      // index of lowest set bit (well-defined because bits != 0 here)
+      const unsigned tz = std::countr_zero(bits);
 
+      // convert that bit to the corresponding power-of-two size
+      const std::size_t ps = 1 << tz;
+
+      // and remove that bit from the input
+      bits &= ~ps;
+
+      // append formatted size; add a comma if there are more bits left
+      std::format_to(std::back_inserter(out), "{}", util::Byte_r(ps).to_string());
+      if (bits) out += ", ";
+    }
     return out;
   }
 
-  inline uintptr_t active_page_size(void* addr) {
-    return active_page_size((uintptr_t) addr);
-  }
+} // namespace os::mem
 
-  inline void
-  virtual_move(uintptr_t src, size_t size, uintptr_t dst, const char* label)
-  {
-    using namespace util::bitops;
-    const auto flags = os::mem::Access::read | os::mem::Access::write;
-    // setup @dst as new virt area for @src
-    os::mem::map({dst, src, flags, size}, label);
-    // unpresent @src
-    os::mem::protect(src, size, os::mem::Access::none);
-  }
-}
-
-
-#endif  // MEM_MEMORY_HPP
+#endif // MEM_VMAP_HPP

--- a/api/util/typename.hpp
+++ b/api/util/typename.hpp
@@ -17,7 +17,7 @@
 
 #include <hal/machine.hpp>
 #include <util/units.hpp>
-#include <kernel/memory.hpp>
+#include <mem/alloc.hpp>
 #include <string>
 
 // Demangle

--- a/lib/LiveUpdate/src/os.cpp
+++ b/lib/LiveUpdate/src/os.cpp
@@ -1,6 +1,6 @@
 #include <kernel.hpp>
 #include <os.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 
 #define HIGHMEM_LOCATION  (1ull << 45)
 //#define LIU_DEBUG 1

--- a/lib/LiveUpdate/src/storage.cpp
+++ b/lib/LiveUpdate/src/storage.cpp
@@ -21,7 +21,7 @@
 #include "storage.hpp"
 #include <os.hpp>
 #include <kernel.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <util/crc32.hpp>
 #include <cassert>
 //#define VERIFY_MEMORY

--- a/lib/LiveUpdate/src/update.cpp
+++ b/lib/LiveUpdate/src/update.cpp
@@ -29,7 +29,6 @@
 #include "storage.hpp"
 #include <kernel.hpp>
 #include <os.hpp>
-#include <kernel/memory.hpp>
 #include <hw/nic.hpp> // for flushing
 
 #define LPRINT(x, ...) printf(x, ##__VA_ARGS__);

--- a/src/arch/aarch64/paging.cpp
+++ b/src/arch/aarch64/paging.cpp
@@ -15,8 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <info>
 #include <arch.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 
 __attribute__((weak))
 void __arch_init_paging()

--- a/src/arch/i686/paging.cpp
+++ b/src/arch/i686/paging.cpp
@@ -15,9 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mem/vmap.hpp"
 #include <arch.hpp>
 #include <info>
-#include <kernel/memory.hpp>
 
 __attribute__((weak))
 void __arch_init_paging()

--- a/src/arch/x86_64/ist.cpp
+++ b/src/arch/x86_64/ist.cpp
@@ -2,7 +2,7 @@
 
 #include <cstdio>
 #include <smp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 
 #ifdef DEBUG_IST
 #define IST_PRINT(X, ...) printf(X, __VA_ARGS__)

--- a/src/kernel/elf.cpp
+++ b/src/kernel/elf.cpp
@@ -479,8 +479,7 @@ void elf_check_symbols_ok()
 }
 
 #ifdef ARCH_x86_64
-#include <kernel/memmap.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <os.hpp>
 void elf_protect_symbol_areas()
 {

--- a/src/kernel/liveupdate.cpp
+++ b/src/kernel/liveupdate.cpp
@@ -1,6 +1,6 @@
 #include <kernel.hpp>
 #include <os.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 
 #define HIGHMEM_LOCATION  (1ull << 45)
 //#define LIU_DEBUG 1

--- a/src/kernel/memmap.cpp
+++ b/src/kernel/memmap.cpp
@@ -17,7 +17,7 @@
 
 #include <sstream>
 #include <iomanip>
-#include <kernel/memmap.hpp>
+#include <mem/memmap.hpp>
 #include <util/units.hpp>
 #include <expects>
 #include <likely>

--- a/src/kernel/multiboot.cpp
+++ b/src/kernel/multiboot.cpp
@@ -20,7 +20,7 @@
 #include <kernel.hpp>
 #include <kprint>
 #include <boot/multiboot.h>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <fmt/format.h>
 
 template<class... Args>

--- a/src/kernel/system_log.cpp
+++ b/src/kernel/system_log.cpp
@@ -1,7 +1,7 @@
 #include <system_log>
 #include <kernel.hpp>
 #include <os.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <ringbuffer>
 #include <kprint>
 

--- a/src/musl/mlock.cpp
+++ b/src/musl/mlock.cpp
@@ -1,5 +1,4 @@
 #include "common.hpp"
-#include <kernel/memory.hpp>
 
 static long sys_mlock(const void* /* addr */, size_t /* len */)
 {

--- a/src/musl/mmap.cpp
+++ b/src/musl/mmap.cpp
@@ -4,7 +4,7 @@
 #include <errno.h>
 #include <mem/alloc/buddy.hpp>
 #include <os>
-#include <kernel/memory.hpp>
+#include <mem/alloc.hpp>
 #include <kernel.hpp>
 #include <kprint>
 

--- a/src/musl/mprotect.cpp
+++ b/src/musl/mprotect.cpp
@@ -1,5 +1,4 @@
 #include "common.hpp"
-#include <kernel/memory.hpp>
 
 static long sys_mprotect(void* /*addr*/, size_t /*len*/, int /*prot*/)
 {

--- a/src/net/buffer_store.cpp
+++ b/src/net/buffer_store.cpp
@@ -18,7 +18,7 @@
 #include <cstdlib>
 #include <net/buffer_store.hpp>
 #include <os>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <cassert>
 #include <smp>
 #include <cstddef>

--- a/src/platform/x86_pc/idt.cpp
+++ b/src/platform/x86_pc/idt.cpp
@@ -4,7 +4,7 @@
 #include <kprint>
 #include <info>
 #include <os>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #define RING0_CODE_SEG   0x8
 
 extern "C" {

--- a/src/platform/x86_pc/os.cpp
+++ b/src/platform/x86_pc/os.cpp
@@ -23,7 +23,7 @@
 #include <os.hpp>
 #include <rtc>
 #include <kernel/events.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <kprint>
 #include <service>
 #include <cstdio>

--- a/src/platform/x86_pc/softreset.cpp
+++ b/src/platform/x86_pc/softreset.cpp
@@ -1,6 +1,5 @@
 #include <os>
 #include <kprint>
-#include <kernel/memory.hpp>
 #include <kernel.hpp>
 #include <util/crc32.hpp>
 using namespace util::literals;

--- a/src/posix/memalign.cpp
+++ b/src/posix/memalign.cpp
@@ -15,9 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cerrno>
 #include <cstdlib>
 #include <malloc.h>
-#include <kernel/memory.hpp>
 #include <util/bitops.hpp>
 
 extern "C"

--- a/test/integration/kernel/memmap/service.cpp
+++ b/test/integration/kernel/memmap/service.cpp
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #include <os>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <util/bitops.hpp>
 
 

--- a/test/integration/memory/paging/service.cpp
+++ b/test/integration/memory/paging/service.cpp
@@ -21,7 +21,7 @@
 #include <service>
 #include <cassert>
 #include <iostream>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <arch/x86/paging.hpp>
 #include <arch/x86/paging_utils.hpp>
 #include <random>

--- a/test/unit/kernel/os_test.cpp
+++ b/test/unit/kernel/os_test.cpp
@@ -17,7 +17,7 @@
 
 #include <common.cxx>
 #include <os.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 
 CASE("version() returns string representation of OS version")
 {

--- a/test/unit/memory/generic/test_memory.cpp
+++ b/test/unit/memory/generic/test_memory.cpp
@@ -23,7 +23,7 @@
 
 #include <common.cxx>
 #include <iostream>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <arch/x86/paging.hpp>
 #include <malloc.h>
 #include <os>

--- a/test/unit/memory/mapping/memmap_test.cpp
+++ b/test/unit/memory/mapping/memmap_test.cpp
@@ -17,7 +17,7 @@
 
 #include <common.cxx>
 #include <iostream>
-#include <kernel/memmap.hpp>
+#include <mem/memmap.hpp>
 using namespace os::mem;
 
 CASE ("Using the fixed memory range class")

--- a/test/unit/memory/paging/x86_paging.cpp
+++ b/test/unit/memory/paging/x86_paging.cpp
@@ -21,7 +21,7 @@
 #include <os>
 #include <arch/x86/paging.hpp>
 #include <arch/x86/paging_utils.hpp>
-#include <kernel/memory.hpp>
+#include <mem/vmap.hpp>
 #include <cmath>
 
 using namespace util;


### PR DESCRIPTION
The old `kernel/memory.hpp` had several responsibilities, and albeit not being super long it felt hard to read. It comprised at least two fairly different parts:
- Setting up a mapping from virtual memory to physical pages (now `mem/vmap.hpp`)
- Setting up the allocator for the heap (now `mem/alloc.hpp`)

Furthermore, I've also created `mem/flags.hpp` since it doesn't quite fit either of them entirely, and it facilitates plans going forward.

Currently, we're assuming architecture-specific/hardware protection flags match IncludeOS-allocation flags. While this is currently the case, I do intend to change this in the future for the sake of type safety. `src/arch/x86_64/paging.cpp` uses `os::mem::Access` referring to hardware flags, while `src/kernel/multiboot.cpp` or `src/kernel/elf.cpp` refers to IncludeOS semantics. I intend to create a per-architecture translation mapping for this (`constexpr`, so it won't affect any performance, of course).

The responsibility separation between `mem/vmap` and `mem/alloc` seems to be represented in the usages across the code too (most of the results are non-overlapping):

```shell
$ rg mem/vmap.hpp | wc -l
18
$ rg mem/alloc.hpp | wc -l
14
```

This PR essentially makes #2329 obsolete.