### PR TITLE
Unify nix wrappers

### DIFF
--- a/chainloader.nix
+++ b/chainloader.nix
@@ -20,6 +20,9 @@
 let
   includeos = pkgs.pkgsIncludeOS.includeos;
   stdenv = pkgs.pkgsIncludeOS.stdenv;
+
+  suppress = includeos.pkgs.callPackage ./nix/suppress.nix {};
+  ccache = includeos.pkgs.callPackage ./nix/ccache.nix {};
 in
 
 assert (stdenv.targetPlatform.system != "i686-linux") ->
@@ -48,5 +51,5 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgs.buildPackages.cmake
     pkgs.buildPackages.nasm
-  ] ++ [ pkgs.pkgsIncludeOS.suppressTargetWarningHook ];
+  ] ++ [ suppress.targetWarningHook ];
 }

--- a/nix/ccache.nix
+++ b/nix/ccache.nix
@@ -1,0 +1,54 @@
+{ pkgs
+, cc
+, ccacheDir ? "/nix/var/cache/ccache"
+, showNotice ? true
+}:
+let
+  noticeHook =
+    if showNotice then
+      pkgs.writeTextFile {
+        name = "ccache-notice-hook";
+        destination = "/nix-support/setup-hook";
+        text = ''
+          echo "====="
+          echo "ccache is enabled!"
+          echo "Disable with: --arg withCcache false"
+          echh ""
+          echo "It's recommended to run tests with ccache disabled to avoid cache incoherencies."
+          echo "====="
+        '';
+      }
+    else
+      null;
+
+  wrapper = pkgs.ccacheWrapper.override {
+    inherit cc;
+
+    extraConfig = ''
+      export CCACHE_DIR="${ccacheDir}"
+      if [ ! -d "$CCACHE_DIR" ]; then
+        echo "====="
+        echo "Directory '$CCACHE_DIR' does not exist"
+        echo "  sudo mkdir -m0770 '$CCACHE_DIR'
+        echo "sudo chown root:nixbld '$CCACHE_DIR'"
+        echo ""
+        echo 'Alternatively, disable ccache with `--arg withCcache false`'
+        echo "====="
+        exit 1
+      fi
+      if [ ! -w "$CCACHE_DIR" ]; then
+        echo "====="
+        echo "Directory '$CCACHE_DIR' exists but isn't writable by $(whoami)"
+        echo "Please verify its access permissions"
+        echo "====="
+        exit 1
+      fi
+      export CCACHE_COMPRESS=1
+      export CCACHE_UMASK=007
+      export CCACHE_SLOPPINESS=random_seed
+    '';
+  };
+in
+{
+  inherit wrapper noticeHook;
+}

--- a/nix/suppress.nix
+++ b/nix/suppress.nix
@@ -1,0 +1,16 @@
+{ pkgs }:
+let
+  targetWarningHook = pkgs.writeTextFile {
+    name = "suppress-target-warning-hook";
+    destination = "/nix-support/setup-hook";
+    text = ''
+          # see https://github.com/NixOS/nixpkgs/issues/395191
+          # delete this hook and downstream references once resolved
+
+          export NIX_CC_WRAPPER_SUPPRESS_TARGET_WARNING=1
+    '';
+  };
+in
+{
+  inherit targetWarningHook;
+}

--- a/unikernel.nix
+++ b/unikernel.nix
@@ -38,6 +38,9 @@ let
       includeos.vmrunner
     else
       includeos.pkgs.callPackage (builtins.toPath /. + vmrunner) {};
+
+  suppress = includeos.pkgs.callPackage ./nix/suppress.nix {};
+  ccache = includeos.pkgs.callPackage ./nix/ccache.nix {};
 in
 includeos.stdenv.mkDerivation rec {
   pname = "includeos_example";
@@ -49,7 +52,7 @@ includeos.stdenv.mkDerivation rec {
   nativeBuildInputs = [
     includeos.pkgs.buildPackages.nasm
     includeos.pkgs.buildPackages.cmake
-  ] ++ [ includeos.pkgs.pkgsIncludeOS.suppressTargetWarningHook ];
+  ] ++ [ suppress.targetWarningHook ];
 
   buildInputs = [
     includeos


### PR DESCRIPTION
Starting the refactor by making standalone targets for `ccache` and our warning suppressor.

This makes our current nix targets cleaner, reduces repeated implementations, and should make it easier to disable them at a single location.

Followup-question: is there a particular motivation for having multiple `stdenv` or `pkgs` versions for different things? If this is not necessary, I would like to refactor how we name and pass these inputs around: Currently we're redefinining `pkgs ? import nixpkgs { }` in four different places. This feels wrong.