### PR TITLE
fix erroneous %s prefixes

### DIFF
--- a/src/kernel/multiboot.cpp
+++ b/src/kernel/multiboot.cpp
@@ -26,7 +26,7 @@
 template<class... Args>
 static inline void _kfmt(fmt::string_view prefix, fmt::format_string<Args...> fmtstr, Args&&... args) {
   fmt::basic_memory_buffer<char, kernel::kprintf_max_size> buf;
-  fmt::format_to_n(std::back_inserter(buf), buf.capacity(), "%s", prefix);
+  fmt::format_to_n(std::back_inserter(buf), buf.capacity(), "{}", prefix);
   fmt::format_to_n(std::back_inserter(buf), buf.capacity() - buf.size(), fmtstr, std::forward<Args>(args)...);
 
   kprintf("%.*s", (int)buf.size(), buf.data());


### PR DESCRIPTION
whoopsie, this fixes an error from 59263d4d which caused wrong output:
```
%sBooted with multiboot
%s* Boot flags: 0x24f
%s* Valid memory (%i KiB):
%s  0x00000000 - 0x0009fbff (639 KiB)
%s  0x00100000 - 0x07fdffff (129920 KiB)
%s
%s* Booted with parameters @ 0x8000: ./result/hello_includeos.elf.bin ""
%s* Multiboot provided memory map  (7 entries @ 0x9000)
%s  0x0 - 0x9fbff FREE (639 KiB)
%s  0x9fc00 - 0x9ffff RESERVED (1 KiB)
%s  0xf0000 - 0xfffff RESERVED (64 KiB)
%s  0x100000 - 0x7fdffff FREE (129920 KiB)
%s  0x7fe0000 - 0x7ffffff RESERVED (128 KiB)
%s  0xfffc0000 - 0xffffffff RESERVED (256 KiB)
%s  0xfd00000000 - 0xffffffffff RESERVED (12582912 KiB)
```

which is now
```
< multiboot >Booted with multiboot
	* Boot flags: 0x24f
	* Valid memory (%i KiB):
	 0x00000000 - 0x0009fbff (639 KiB)
	 0x00100000 - 0x07fdffff (129920 KiB)

	* Booted with parameters @ 0x3bf034: /nix/store/6sanwglx91v4h772bx8azvrkq3a63414-chainloader-static-i686-unknown-linux-musl-dev/bin/chainloader ""
	* Multiboot provided memory map  (7 entries @ 0x9000)
	 0x0 - 0x9fbff FREE (639 KiB)
	 0x9fc00 - 0x9ffff RESERVED (1 KiB)
	 0xf0000 - 0xfffff RESERVED (64 KiB)
	 0x100000 - 0x7fdffff FREE (129920 KiB)
	 0x7fe0000 - 0x7ffffff RESERVED (128 KiB)
	 0xfffc0000 - 0xffffffff RESERVED (256 KiB)
	 0x0 - 0xffffffff RESERVED (0 KiB)
```

as it was before.

Note that by using `std::format_to_n` we don't run into futex issues even this early.