### PR TITLE
remove deprecated python2 imports

### DIFF
--- a/test/integration/kernel/kprint/test.py
+++ b/test/integration/kernel/kprint/test.py
@@ -3,7 +3,6 @@
 from __future__ import division
 from __future__ import print_function
 from builtins import str
-from past.utils import old_div
 import sys
 import os
 
@@ -27,7 +26,7 @@ def set_format_string_size(line):
 def check_truncation(line):
   assert(format_string_size)
 
-  print("Received truncated string: ", line, "of size", len(line), "(format size * ", old_div(len(line),format_string_size),")")
+  print("Received truncated string: ", line, "of size", len(line), "(format size * ", len(line)//format_string_size,")")
   assert(len(line) <= format_string_size * 2)
   # truncated outputs are unacceptable :)
   assert(line.strip().split(" ")[-1] == "END")

--- a/test/integration/net/http/test.py
+++ b/test/integration/net/http/test.py
@@ -1,18 +1,16 @@
 #!/usr/bin/env python3
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-import sys
-import os
 import _thread
+import http.server
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 
 from vmrunner import vmrunner
 
 HOST = ''
 PORT = 9011
-
-import http.server
 
 DO_SERVE = True
 class RequestHandler(http.server.BaseHTTPRequestHandler):
@@ -36,7 +34,6 @@ def Client_test():
 _thread.start_new_thread(Client_test, ())
 
 
-import urllib.request, urllib.error, urllib.parse
 def Server_test(triggerline):
     res = urllib.request.urlopen("http://10.0.0.46:8080").read()
     assert(res.decode('utf-8') == "Hello")


### PR DESCRIPTION
Some tests were using imports that permit compatibility with python2. They are no longer necessary, and causes tests to fail.

All tests pass with these changes.

Closes #2362.