### PR TITLE
kernel: fix dangling multiboot cmdline and libc env pointers

### DIFF
--- a/src/kernel/multiboot.cpp
+++ b/src/kernel/multiboot.cpp
@@ -181,11 +181,7 @@ void kernel::multiboot(uint32_t boot_addr)
   if (info->flags & MULTIBOOT_INFO_CMDLINE) {
     const auto* cmdline = (const char*) (uintptr_t) info->cmdline;
     INFO2("* Booted with parameters @ {}: {}", (const void*)(uintptr_t)info->cmdline, cmdline);
-    // Multiboot cmdline lives in bootloader-provided memory for the lifetime of
-    // the kernel. _multiboot_free_begin() reserves it when it sits past _end
-    // (and low-memory cmdlines are outside the free region). Do not copy into a
-    // temporary and store .data() — that dangles (see issue #2368 / #2273).
-    // Also avoid strdup/malloc here: early boot must not call into libc (#2252).
+    // Bootloader memory (_multiboot_free_begin); no temp .data()/strdup.
     kernel::state().cmdline = cmdline;
   }
 

--- a/src/kernel/multiboot.cpp
+++ b/src/kernel/multiboot.cpp
@@ -181,7 +181,12 @@ void kernel::multiboot(uint32_t boot_addr)
   if (info->flags & MULTIBOOT_INFO_CMDLINE) {
     const auto* cmdline = (const char*) (uintptr_t) info->cmdline;
     INFO2("* Booted with parameters @ {}: {}", (const void*)(uintptr_t)info->cmdline, cmdline);
-    kernel::state().cmdline = std::pmr::string(cmdline).data();
+    // Multiboot cmdline lives in bootloader-provided memory for the lifetime of
+    // the kernel. _multiboot_free_begin() reserves it when it sits past _end
+    // (and low-memory cmdlines are outside the free region). Do not copy into a
+    // temporary and store .data() — that dangles (see issue #2368 / #2273).
+    // Also avoid strdup/malloc here: early boot must not call into libc (#2252).
+    kernel::state().cmdline = cmdline;
   }
 
   if (info->flags & MULTIBOOT_INFO_MEM_MAP) {

--- a/src/platform/x86_pc/init_libc.cpp
+++ b/src/platform/x86_pc/init_libc.cpp
@@ -110,10 +110,13 @@ namespace x86
     argv[1] = 0x0;
     int argc = 1;
 
-    // Env vars
-    argv[2] = std::pmr::string("LC_CTYPE=C").data();
-    argv[3] = std::pmr::string("LC_ALL=C").data();
-    argv[4] = std::pmr::string("USER=root").data();
+    // Env vars (static storage — not .data() of a temporary pmr::string)
+    static char env_lc_ctype[] = "LC_CTYPE=C";
+    static char env_lc_all[]   = "LC_ALL=C";
+    static char env_user[]     = "USER=root";
+    argv[2] = env_lc_ctype;
+    argv[3] = env_lc_all;
+    argv[4] = env_user;
     argv[5] = 0x0;
 
     // auxiliary vector


### PR DESCRIPTION
## Summary

- Multiboot cmdline: keep the bootloader-provided pointer in `kernel::state().cmdline` instead of `.data()` from a temporary `std::pmr::string` (dangling after the full-expression). Memory is already reserved via `_multiboot_free_begin()` when the string sits past `_end`.
- Avoid early `strdup`/malloc on this path (see #2252 / #2273).
- `init_libc`: env strings for `__libc_start_main` use static buffers instead of temporary `pmr::string` `.data()`.

Closes: #2368

## Test plan

- [x] `nix-build unittests.nix` — 85/85 passed
- [x] Confirmed no dangling-assignment warning on `multiboot.cpp` in the unit build log
- [ ] Full `./test/test.sh` integration suite not run